### PR TITLE
[DPAV-112]: fixed realtime trains integration

### DIFF
--- a/frontend/src/declarations.d.ts
+++ b/frontend/src/declarations.d.ts
@@ -40,7 +40,6 @@ interface ImportMetaEnv {
   readonly VITE_ONTOLOGY_SERVICE_URL?: string;
   readonly VITE_AUTH_TEST_URL?: string;
   readonly VITE_MAP_TILER_TOKEN?: string;
-  readonly VITE_ORDNANCE_SURVEY_API_KEY?: string;
   readonly VITE_CANNY_APP_ID?: string;
   readonly VITE_CANNY_BOARD_TOKEN?: string;
   readonly VITE_MET_OFFICE_GLOBAL_SPOT_API_KEY?: string;
@@ -48,7 +47,6 @@ interface ImportMetaEnv {
    * @deprecated Use VITE_MET_OFFICE_GLOBAL_SPOT_API_KEY instead
    */
   readonly VITE_GLOBAL_SPOT_MET_OFFICE_API_KEY?: string;
-  readonly VITE_REAL_TIME_TRAINS_API_KEY?: string;
 }
 
 interface ImportMeta {

--- a/transparent-proxy/proxy.conf.template
+++ b/transparent-proxy/proxy.conf.template
@@ -80,7 +80,7 @@ server {
 
     # Realtime Trains
     location /realtime-trains/ {
-        proxy_pass https://secure.realtimetrains.co.uk/api/;
+        proxy_pass https://api.rtt.io/api/v1/;
 
         proxy_set_header Authorization "Basic $REALTIME_TRAINS_API_KEY";
     }


### PR DESCRIPTION
Changed the URL for the realtime trains API as I could not find any reference to the previous one. It works identically to the coefficient deployed version.

You can find more information regarding the realtime trains API [here](https://www.realtimetrains.co.uk/about/developer/pull/docs/).