### PR TITLE
DPAV-552: update assessments api

### DIFF
--- a/frontend/src/api/assessments.ts
+++ b/frontend/src/api/assessments.ts
@@ -9,17 +9,22 @@ interface Assessment {
   uri: string;
 }
 
-export const fetchAssessments = async () => {
-  const response = await fetch(
-    createParalogEndpoint("assessments"),
-    fetchOptions,
-  );
+export const fetchAssessments = async (): Promise<Assessment[]> => {
+  try {
+    const response = await fetch(
+      createParalogEndpoint("assessments"),
+      fetchOptions,
+    );
 
-  if (!response.ok) {
-    throw new Error(`Failed to retrieve assessments`);
+    if (!response.ok) {
+      throw new Error(`Failed to retrieve assessments: ${response.statusText}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error("Error fetching assessments:", error);
+    throw error;
   }
-
-  return (await response.json()) as Assessment[];
 };
 
 interface AssessmentDependency {
@@ -44,29 +49,37 @@ interface AssessmentDependency {
 }
 
 export const fetchAssessmentDependencies = async (
-  assessment: string,
+  assessment: string = "DEFAULT_ASSESSMENT",
   types: string[],
-) => {
-  const body = JSON.stringify({ assessment, types });
+): Promise<AssessmentDependency[]> => {
+  try {
+    const body = JSON.stringify({ assessment, types });
 
-  const response = await fetch(
-    createParalogEndpoint(`assessments/dependencies`),
-    {
-      ...fetchOptions,
-      method: "POST",
-      headers: {
-        ...fetchOptions.headers,
-        "Content-Type": "application/json",
+    const response = await fetch(
+      createParalogEndpoint("assessments/dependencies"),
+      {
+        ...fetchOptions,
+        method: "POST",
+        headers: {
+          ...fetchOptions.headers,
+          "Content-Type": "application/json",
+        },
+        body,
       },
-      body,
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `An error occurred while retrieving dependencies for assessment ${assessment} and types ${types.toString()}`,
     );
-  }
 
-  return (await response.json()) as AssessmentDependency[];
+    if (!response.ok) {
+      throw new Error(
+        `Failed to retrieve dependencies for assessment "${assessment}" with types: ${types.join(", ")}`,
+      );
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error(
+      `Error fetching dependencies for assessment "${assessment}":`,
+      error,
+    );
+    throw error;
+  }
 };


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

 Currently /dependencies api is expecting a parameter “assessment“ which can hold an extremely long value. this value can not be passed as query string and the api require to change so that it changes from “GET“ to “POST“ and submit the assessment data within the body as opposed to the query string header. 
 
 https://ndtp.atlassian.net/browse/DPAV-552 

## Description

- HTTP Method:
Switch from GET to POST.
- Request Body:
Instead of appending the assessment and types as query parameters, include them in the JSON body.
- Headers:
Ensure that the Content-Type header is set to "application/json".
- Endpoint URL:
Remove the query string from the URL since all data is now sent in the body.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
