### PR TITLE
DPAV-668: Hides the "Close Control Panel" icon when the panel is closed.

### DIFF
--- a/frontend/src/components/Map/ControlsOverlay/index.tsx
+++ b/frontend/src/components/Map/ControlsOverlay/index.tsx
@@ -89,11 +89,14 @@ export default function ControlsOverlay() {
         </Grid2>
         <Grid2 size={dependantPanelOpen ? 5 : 8}>
           <div style={{ marginTop: "10px" }} className="pointer-events-auto">
-            <MToolbar
-              onOpenControlPanel={
-                featureFlags.uiNext && controlPanelOpen && hideControlPanel
-              }
-            />
+            {controlPanelOpen && ( // Only show close button when the panel is open
+              <MToolbar
+                onOpenControlPanel={() => {
+                  hideControlPanel(); // Hide Control Panel
+                  hideConnectedAssetsPanel(); // Also hide Connected Assets Panel
+                }}
+              />
+            )}
           </div>
         </Grid2>
         <Grid2
@@ -120,6 +123,7 @@ export default function ControlsOverlay() {
     </Grid2>
   );
 }
+
 
 function DetailPanels() {
   const tools = useTools();


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://ndtp.atlassian.net/browse/DPAV-668
## Description
Ensures that when "Close Control Panel" is clicked, both the Control Panel and Connected Asset Panel close.
<!--- Describe your changes in detail -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
