### PR TITLE
bugfix(non-req): updated transparent proxy cache settings

### DIFF
--- a/transparent-proxy/proxy.conf.template
+++ b/transparent-proxy/proxy.conf.template
@@ -29,7 +29,7 @@ server {
   resolver kube-dns.kube-system.svc.cluster.local valid=30s;
 
   # Proxy config
-  proxy_cache_valid any 1d;
+  proxy_cache_valid 200 302 10m;
   proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
   proxy_cache_revalidate on;
   proxy_cache_background_update on;


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The transparent proxy was set to cache any response for 1 day which can result in invalid responses being cached and returned.

## Description

<!--- Describe your changes in detail -->
- Changed the response types and duration for caching on Paralog.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Tested locally and the proxy is working as expected.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
