### PR TITLE
bugfix(non-req): increased resiliency of the transparent proxy

### DIFF
--- a/transparent-proxy/proxy.conf.template
+++ b/transparent-proxy/proxy.conf.template
@@ -26,15 +26,17 @@ server {
 
   server_name localhost *.ndtp.co.uk;
 
-  resolver kube-dns.kube-system.svc.cluster.local valid=30s;
+  resolver kube-dns.kube-system.svc.cluster.local valid=1m;
 
   # Proxy config
   proxy_cache_valid 200 302 10m;
   proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+  proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
   proxy_cache_revalidate on;
   proxy_cache_background_update on;
   proxy_http_version 1.1;
   proxy_cache tp_cache;
+  proxy_next_upstream_tries 3;
 
   # Do not allow cookies
   proxy_hide_header Set-Cookie;
@@ -124,8 +126,8 @@ server {
 
   ## END UPSTREAM DEFINITIONS
 
-  if ($upstream_http_content_type ~* "(text/html|application/xhtml+xml|text/javascript|application/javascript)") {
+  # if ($upstream_http_content_type ~* "(text/html|application/xhtml+xml|text/javascript|application/javascript)") {
     # Block upstreams ever serving us "dangerous" content
-    return 502;
-  }
+    # return 502;
+  # }
 }


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were a couple of issues when it comes to the resiliency aspect of the transparent proxy.
- The resolver validity time was too short leading to DNS resolver issues
- There were no retries incase an error response was returned from an endpoint

## Description

<!--- Describe your changes in detail -->
- Increased the DNS resolver validity to 1 minute
- Added retry mechanism for failed proxy requests
- Commented out returning the 502 response incase an unexpected content type was returned from one of the endpoints (for testing)

## How Has This Been Tested?
Tested e2e locally but main test will be for deployed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
