### PR TITLE
bugfix(non-req): added logging annotation to adjust log level of istio proxy

### DIFF
--- a/k8s/transparent-proxy/base/deployment.yaml
+++ b/k8s/transparent-proxy/base/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         traffic.sidecar.istio.io/inject: "false"
         traffic.sidecar.istio.io/excludeOutboundPorts: "8200"
+        traffic.sidecar.istio.io/agentLogLevel: trace
       labels:
         io.kompose.service: vista-transparent-proxy
     spec:

--- a/transparent-proxy/proxy.conf.template
+++ b/transparent-proxy/proxy.conf.template
@@ -31,12 +31,10 @@ server {
   # Proxy config
   proxy_cache_valid 200 302 10m;
   proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
-  proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
   proxy_cache_revalidate on;
   proxy_cache_background_update on;
   proxy_http_version 1.1;
   proxy_cache tp_cache;
-  proxy_next_upstream_tries 3;
 
   # Do not allow cookies
   proxy_hide_header Set-Cookie;
@@ -126,8 +124,8 @@ server {
 
   ## END UPSTREAM DEFINITIONS
 
-  # if ($upstream_http_content_type ~* "(text/html|application/xhtml+xml|text/javascript|application/javascript)") {
+  if ($upstream_http_content_type ~* "(text/html|application/xhtml+xml|text/javascript|application/javascript)") {
     # Block upstreams ever serving us "dangerous" content
-    # return 502;
-  # }
+    return 502;
+  }
 }


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The default log level of the istio proxy is debug which is not enough for debugging the realtime trains issue.

## Description

<!--- Describe your changes in detail -->
- Changed the log level of the istio proxy to debug
- Reverted change to comment out returning a 502 when an unexpected content type is returned.
- Reverted code for triggering retries from nginx as it was not working.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested when deployed.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
