### PR TITLE
bugfix(non-req): queued the arrivals call after the departure call is done

### DIFF
--- a/frontend/src/tools/Train/TrainDetailPanel.tsx
+++ b/frontend/src/tools/Train/TrainDetailPanel.tsx
@@ -25,7 +25,7 @@ export default function TrainDetailPanel() {
   const { data: arrivalData, isLoading: isArrivalsLoading } = useQuery({
     queryKey: ["train-arrivals", selectedStation],
     queryFn: () => fetchTrainArrivals(stationObj?.NLC || ""),
-    enabled: !!selectedStation,
+    enabled: !!selectedStation && !!departureData,
   });
 
   const isLoading = isDeparturesLoading || isArrivalsLoading;

--- a/transparent-proxy/proxy.conf.template
+++ b/transparent-proxy/proxy.conf.template
@@ -27,6 +27,7 @@ server {
   server_name localhost *.ndtp.co.uk;
 
   resolver kube-dns.kube-system.svc.cluster.local valid=1m;
+  # resolver 8.8.8.8 valid=1m;
 
   # Proxy config
   proxy_cache_valid 200 302 10m;


### PR DESCRIPTION

## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The arrival and departure calls were being done asynchronously at the same time. This might lead to DNS resolution issues and result in a 502 response being returned from the nginx proxy for realtime trains.

## Description

<!--- Describe your changes in detail -->
- Queued the arrivals request until after the departure request is done.

## How Has This Been Tested?
Tested locally and is working e2e.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
