### PR TITLE
bugfix(non-req): disabled istio sidecar interception on outbound requests

### DIFF
--- a/k8s/transparent-proxy/base/deployment.yaml
+++ b/k8s/transparent-proxy/base/deployment.yaml
@@ -15,8 +15,10 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/logLevel: trace
-        traffic.sidecar.istio.io/inject: "false"
         traffic.sidecar.istio.io/excludeOutboundPorts: "8200"
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_INTERCEPTION_MODE: NONE
       labels:
         io.kompose.service: vista-transparent-proxy
     spec:


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Istio is intercepting outbound requests from the transparent proxy to the external APIs. This might be causing issues with the requests and resulting in the intermittent 502s we are seeing with realtime trains.

## Description

<!--- Describe your changes in detail -->
- Added an annotation to not have istio intercept outbound requests via the transparent proxy.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Can only be tested once deployed.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
