### PR TITLE
fix(OSPO): exclude .github directory from prettier checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
       - id: check-yaml
-        exclude: ^\.github/
       - id: check-added-large-files
         name: Check for files larger than 5 MB
         args: ["--maxkb=5120"]
@@ -78,3 +77,4 @@ repos:
         types_or: [yaml]
         additional_dependencies:
           - "prettier@3.5.3"
+        exclude: ^\.github/


### PR DESCRIPTION
## Sensitive Credential Checks
- [X] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context
Exclude .github directory from prettier checks as this is outside the scope of application code for formatting.

## Description
Excludes the .github directory from prettier checks as this is outside the scope of application code for formatting.

## How Has This Been Tested?
Tested via this PR.

## Checklist:
- [X] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
