### PR TITLE
bugfix(DPAV-1141): fix features being removed from map

### DIFF
--- a/frontend/src/context/DrawingMode/index.tsx
+++ b/frontend/src/context/DrawingMode/index.tsx
@@ -32,6 +32,8 @@ import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import "./maplibre-gl-draw.css";
 import "./maplibre-gl-map.css";
 import useSharedStore, { State } from "@/hooks/useSharedStore";
+import DrawnPolygonProvider from "@/tools/DrawnPolygons/DrawnPolygonProvider";
+import DynamicProximityProvider from "@/tools/DynamicProximity/DynamicProximityProvider";
 
 /** Context for Drawing Mode */
 interface DrawingModeContextValue {
@@ -120,7 +122,9 @@ export function DrawingModeContextProvider({
 
   return (
     <DrawingModeContext.Provider value={contextValue}>
-      {children}
+      <DrawnPolygonProvider>
+        <DynamicProximityProvider>{children}</DynamicProximityProvider>
+      </DrawnPolygonProvider>
       <RadiusDialog
         open={isRadiusDialogOpen}
         onClose={handleRadiusDialogClose}

--- a/frontend/src/tools/DrawnPolygons/DrawnPolygonLayerControl.tsx
+++ b/frontend/src/tools/DrawnPolygons/DrawnPolygonLayerControl.tsx
@@ -1,6 +1,5 @@
 import DrawnPolygonMenuBody from "./DrawnPolygonMenuBody";
 import type { LayerControlProps } from "@/tools/Tool";
-
 import ComplexLayerControl from "@/components/ComplexLayerControl";
 
 export default function DrawnPolygonLayerControl({

--- a/frontend/src/tools/DrawnPolygons/DrawnPolygonProvider.tsx
+++ b/frontend/src/tools/DrawnPolygons/DrawnPolygonProvider.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext } from "react";
+import { useDrawnPolygonDrawing } from "./useDrawnPolygonDrawing";
+
+interface DrawnPolygonDrawingContextValue {
+  startCircleDrawing: () => void;
+  startPolygonDrawing: () => void;
+}
+
+const DrawnPolygonDrawingContext =
+  createContext<DrawnPolygonDrawingContextValue | null>(null);
+
+export function useDrawnPolygonDrawingContext() {
+  const context = useContext(DrawnPolygonDrawingContext);
+  if (!context) {
+    throw new Error(
+      "useDrawnPolygonDrawingContext must be used within DrawnPolygonProvider",
+    );
+  }
+  return context;
+}
+
+export default function DrawnPolygonProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { startCircleDrawing, startPolygonDrawing } = useDrawnPolygonDrawing();
+
+  const contextValue = { startCircleDrawing, startPolygonDrawing };
+
+  return (
+    <DrawnPolygonDrawingContext.Provider value={contextValue}>
+      {children}
+    </DrawnPolygonDrawingContext.Provider>
+  );
+}

--- a/frontend/src/tools/DrawnPolygons/useDrawnPolygonDrawing.ts
+++ b/frontend/src/tools/DrawnPolygons/useDrawnPolygonDrawing.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useDrawingMode } from "@/context/DrawingMode";
+import { usePolygonToolbarStore } from "@/tools/Polygons/useStore";
+import useSharedStore from "@/hooks/useSharedStore";
+
+export function useDrawnPolygonDrawing() {
+  const { setActiveDrawingMode } = usePolygonToolbarStore();
+
+  const drawingModeCallbacks = useSharedStore(
+    useShallow((state) => ({
+      onAddFeatures: state.addFloodAreaFeatures,
+      onUpdateFeatures: state.updateFloodAreaFeatures,
+      onDeleteFeatures: state.deleteFloodAreaFeatures,
+    })),
+  );
+
+  const { startDrawing, features } = useDrawingMode(
+    (state) =>
+      state.floodAreaFeatures.filter(
+        (feature) =>
+          feature.id && state.selectedFloodAreaFeatureIds[feature.id],
+      ),
+    {
+      onDrawingEnd: () => {
+        setActiveDrawingMode(null);
+      },
+      ...drawingModeCallbacks,
+    },
+  );
+
+  const startCircleDrawing = useCallback(() => {
+    setActiveDrawingMode("drag_circle");
+    startDrawing({ drawingMode: "drag_circle" });
+  }, [startDrawing, setActiveDrawingMode]);
+
+  const startPolygonDrawing = useCallback(() => {
+    setActiveDrawingMode("draw_polygon");
+    startDrawing({ drawingMode: "draw_polygon" });
+  }, [startDrawing, setActiveDrawingMode]);
+
+  return {
+    features,
+    startCircleDrawing,
+    startPolygonDrawing,
+  };
+}

--- a/frontend/src/tools/DynamicProximity/DynamicProximityLayerControl.tsx
+++ b/frontend/src/tools/DynamicProximity/DynamicProximityLayerControl.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import useDynamicProximity from "./useDynamicProximity";
+import { useDynamicProximityDrawingContext } from "./DynamicProximityProvider";
 import ComplexLayerControl from "@/components/ComplexLayerControl";
 import SearchConditional from "@/components/SearchConditional";
 import type { LayerControlProps } from "@/tools/Tool";
@@ -39,7 +39,7 @@ function DynamicProximityMenuItem({
   radiusKm,
   onClick,
 }: DynamicProximityMenuItemProps) {
-  const { startDrawingWithRange } = useDynamicProximity();
+  const { startDrawingWithRange } = useDynamicProximityDrawingContext();
 
   const clicked = useCallback(() => {
     startDrawingWithRange(radiusKm);

--- a/frontend/src/tools/DynamicProximity/DynamicProximityProvider.tsx
+++ b/frontend/src/tools/DynamicProximity/DynamicProximityProvider.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext } from "react";
+import useDynamicProximity from "./useDynamicProximity";
+
+interface DynamicProximityDrawingContextValue {
+  startDrawingWithRange: (radiusKm: number) => void;
+}
+
+const DynamicProximityDrawingContext =
+  createContext<DynamicProximityDrawingContextValue | null>(null);
+
+export function useDynamicProximityDrawingContext() {
+  const context = useContext(DynamicProximityDrawingContext);
+  if (!context) {
+    throw new Error(
+      "useDynamicProximityDrawingContext must be used within DynamicProximityProvider",
+    );
+  }
+  return context;
+}
+
+export default function DynamicProximityProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { startDrawingWithRange } = useDynamicProximity();
+
+  const contextValue = { startDrawingWithRange };
+
+  return (
+    <DynamicProximityDrawingContext.Provider value={contextValue}>
+      {children}
+    </DynamicProximityDrawingContext.Provider>
+  );
+}

--- a/frontend/src/tools/Polygons/CircleCreationButton.tsx
+++ b/frontend/src/tools/Polygons/CircleCreationButton.tsx
@@ -1,49 +1,21 @@
 import { useCallback } from "react";
-import { useShallow } from "zustand/react/shallow";
-
 import { usePolygonToolbarStore } from "./useStore";
 import ToolbarButton from "@/components/Map/SideButtons/ToolbarButton";
-import { useDrawingMode } from "@/context/DrawingMode";
-import useSharedStore from "@/hooks/useSharedStore";
+import { useDrawnPolygonDrawingContext } from "@/tools/DrawnPolygons/DrawnPolygonProvider";
 
 export function CircleCreationButton() {
-  const drawingModeCallbacks = useSharedStore(
-    useShallow((state) => ({
-      onAddFeatures: state.addFloodAreaFeatures,
-      onUpdateFeatures: state.updateFloodAreaFeatures,
-      onDeleteFeatures: state.deleteFloodAreaFeatures,
-    })),
-  );
+  const { startCircleDrawing } = useDrawnPolygonDrawingContext();
+  const { activeDrawingMode } = usePolygonToolbarStore();
 
-  const { setActiveDrawingMode, activeDrawingMode } = usePolygonToolbarStore();
   const isDrawing = activeDrawingMode === "drag_circle";
   const isDisabled = activeDrawingMode !== null && !isDrawing;
-
-  const { startDrawing } = useDrawingMode(
-    (state) =>
-      state.floodAreaFeatures.filter(
-        (feature) =>
-          feature.id && state.selectedFloodAreaFeatureIds[feature.id],
-      ),
-    {
-      onDrawingStart: () => {
-        setActiveDrawingMode("drag_circle");
-      },
-      onDrawingEnd: () => {
-        setActiveDrawingMode(null);
-      },
-      ...drawingModeCallbacks,
-    },
-  );
 
   const drawCircle = useCallback(() => {
     if (isDrawing) {
       return;
     }
-    startDrawing({
-      drawingMode: "drag_circle",
-    });
-  }, [startDrawing, isDrawing]);
+    startCircleDrawing();
+  }, [startCircleDrawing, isDrawing]);
 
   return (
     <ToolbarButton

--- a/frontend/src/tools/Polygons/FreehandCreationButton.tsx
+++ b/frontend/src/tools/Polygons/FreehandCreationButton.tsx
@@ -1,53 +1,21 @@
 import { useCallback } from "react";
-import { useShallow } from "zustand/react/shallow";
-
 import { usePolygonToolbarStore } from "./useStore";
 import ToolbarButton from "@/components/Map/SideButtons/ToolbarButton";
-import { useDrawingMode } from "@/context/DrawingMode";
-import useSharedStore from "@/hooks/useSharedStore";
+import { useDrawnPolygonDrawingContext } from "@/tools/DrawnPolygons/DrawnPolygonProvider";
 
 export function FreehandCreationButton() {
-  const drawingModeCallbacks = useSharedStore(
-    useShallow((state) => ({
-      features: state.floodAreaFeatures,
-      selectedFeatureIds: state.selectedFloodAreaFeatureIds,
-      selected: state.selectedFloodAreas,
-      setSelected: state.setSelectedFloodAreas,
-      toggleFeature: state.toggleFloodAreaFeature,
-      setFeatures: state.setFloodAreaFeatures,
-      onAddFeatures: state.addFloodAreaFeatures,
-      onUpdateFeatures: state.updateFloodAreaFeatures,
-      onDeleteFeatures: state.deleteFloodAreaFeatures,
-    })),
-  );
+  const { startPolygonDrawing } = useDrawnPolygonDrawingContext();
+  const { activeDrawingMode } = usePolygonToolbarStore();
 
-  const { setActiveDrawingMode, activeDrawingMode } = usePolygonToolbarStore();
   const isDrawing = activeDrawingMode === "draw_polygon";
   const isDisabled = activeDrawingMode !== null && !isDrawing;
-
-  const { startDrawing } = useDrawingMode(
-    (state) =>
-      state.floodAreaFeatures.filter(
-        (feature) =>
-          feature.id && state.selectedFloodAreaFeatureIds[feature.id],
-      ),
-    {
-      onDrawingStart: () => {
-        setActiveDrawingMode("draw_polygon");
-      },
-      onDrawingEnd: () => {
-        setActiveDrawingMode(null);
-      },
-      ...drawingModeCallbacks,
-    },
-  );
 
   const drawPolygon = useCallback(() => {
     if (isDrawing) {
       return;
     }
-    startDrawing({ drawingMode: "draw_polygon" });
-  }, [startDrawing, isDrawing]);
+    startPolygonDrawing();
+  }, [startPolygonDrawing, isDrawing]);
 
   return (
     <ToolbarButton


### PR DESCRIPTION
Moved drawing feature management to persistent providers to prevent mapbox-gl-draw cleanup when components unmount. Features now survive panel collapse and toolbar toggles, also made the same change for dynamic proximity features as well.

## Sensitive Credential Checks

- [ ] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

When closing the draw mode the circles disappeared from the map as features were removed from the draw due to them being unmounted.

## Description

Now using one version of it higher up to prevent it being ummounted when things are closed

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
