### PR TITLE
fix(DPAV-1141): hide polygon layer control when empty

### DIFF
--- a/frontend/src/tools/DrawnPolygons/DrawnPolygonLayerControl.tsx
+++ b/frontend/src/tools/DrawnPolygons/DrawnPolygonLayerControl.tsx
@@ -1,6 +1,7 @@
 import DrawnPolygonMenuBody from "./DrawnPolygonMenuBody";
 import type { LayerControlProps } from "@/tools/Tool";
 import ComplexLayerControl from "@/components/ComplexLayerControl";
+import useSharedStore from "@/hooks/useSharedStore";
 
 export default function DrawnPolygonLayerControl({
   searchQuery,
@@ -17,7 +18,9 @@ export default function DrawnPolygonLayerControl({
 
   const matchesAnyTerm = !searchQuery || matchesParentCategory;
 
-  if (!matchesAnyTerm) {
+  const features = useSharedStore((state) => state.floodAreaFeatures);
+
+  if (!matchesAnyTerm || !features?.length) {
     return null;
   }
 


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

When there are no drawn polygons to manage the menu control still draws and doesn't look good.

## Description

Hide if there are no features in the store

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
