### PR TITLE
bugfix: [DPAV-1399] filter grassland in memory

### DIFF
--- a/frontend/src/data/live-assets.json
+++ b/frontend/src/data/live-assets.json
@@ -711,7 +711,13 @@
         "type": "http://ies.data.gov.uk/ontology/ies4#OpenGrassland",
         "source": "os_ngd",
         "collection": "lnd-fts-land-3",
-        "cqlFilter": "description='Bare Earth Or Grass' AND geometry_area_m2 > 10000",
+        "filters": [
+            {
+                "filterName": "description",
+                "filterValue": "Bare Earth Or Grass"
+            }
+        ],
+        "cqlFilter": "geometry_area_m2 > 10000",
         "styles": {
             "classUri": "http://ies.data.gov.uk/ontology/ies4#OpenGrassland",
             "backgroundColor": "#242400",


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Istio Envoy is misinterpreting the `AND` character in the query string generated from the `cqlFilter`, causing the request to be routed to the web application rather than the transparent proxy. 

## Description
This fix filters the API solely by the `geometry_area_m2` as this returns the smallest dataset over `bare earth or grass` land - and then the dataset is filtered in memory down to areas of grassland.
<!--- Describe your changes in detail -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
Manually.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
