### PR TITLE
bugfix(DPAV-2020): clear inline rather than setting to grab

### DIFF
--- a/frontend/src/context/DrawingMode/index.tsx
+++ b/frontend/src/context/DrawingMode/index.tsx
@@ -164,6 +164,10 @@ export const useDrawingMode = <T extends Feature>(
         [map],
     );
 
+    const resetCursor = useCallback(() => {
+        setCursor('');
+    }, [setCursor]);
+
     const updateRadiusLabel = useCallback(
         (centerCoords: [number, number], edgeCoords: [number, number]) => {
             if (!map) {
@@ -313,7 +317,7 @@ export const useDrawingMode = <T extends Feature>(
             const handleDrawCreate = (event: DrawCreateEvent) => {
                 onAddFeatures(event.features);
                 removeMouseListeners();
-                setCursor('grab');
+                resetCursor();
                 onDrawingEnd?.();
                 map.off('draw.create', handleDrawCreate);
                 map.off('draw.modechange', handleModeChange);
@@ -324,7 +328,7 @@ export const useDrawingMode = <T extends Feature>(
                 if (event.mode === 'simple_select') {
                     if (drawingMode === 'drag_circle') {
                         map.getMap().dragPan.enable();
-                        setCursor('grab');
+                        resetCursor();
                     }
                     onDrawingEnd?.();
                 }
@@ -390,7 +394,19 @@ export const useDrawingMode = <T extends Feature>(
             map.on('draw.create', handleDrawCreate);
             map.on('draw.modechange', handleModeChange);
         },
-        [draw, map, onDrawingStart, onDrawingEnd, onAddFeatures, handleDrawEvent, updateRadiusLabel, removeRadiusLabel, showRadiusDialog, setCursor],
+        [
+            draw,
+            map,
+            onDrawingStart,
+            onDrawingEnd,
+            onAddFeatures,
+            handleDrawEvent,
+            updateRadiusLabel,
+            removeRadiusLabel,
+            showRadiusDialog,
+            setCursor,
+            resetCursor,
+        ],
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [x] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

When drawing a polygon using the freehand draw tool a the icon of the pointer is not changing to crosshair and remains as a hand.

This only happens when a freehand polygon has already been drawn.

The expected bhaviour is to always change the icon of the point to a crosshair when drawing a polygon in freehand mode regardless of how many you are drawing.

https://ndtp.atlassian.net/browse/DPAV-2020

## Description

clear inline rather than setting to grab
    
    using setCursor('grab') was preventing mapbox draws CSS classes from
    styling the cursor properly, so it worked the first time until drawing
    completed and it was set to grab, then the mouse-add class was
    overridden by this so the crosshair didn't show trying to draw again.


## How Has This Been Tested?

Locally

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
