### PR TITLE
feature(DPAV-1988): update asset-types endpoint and add clear visible endpoint

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -3807,21 +3807,21 @@ markers = {dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.1"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
+    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "uvicorn"

--- a/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
+++ b/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
@@ -304,3 +304,146 @@ def test_scenario_assets_exclude_map_wide(
     data = response.json()
     assert len(data) == 1
     assert data[0]["name"] == "Hospital Inside"
+
+
+def find_asset_type_in_tree(data, asset_type_name):
+    """Find an asset type by name in the nested category tree."""
+    for category in data:
+        for sub_category in category.get("subCategories", []):
+            for asset_type in sub_category.get("assetTypes", []):
+                if asset_type["name"] == asset_type_name:
+                    return asset_type
+    return None
+
+
+def get_all_asset_type_names(data):
+    """Get all asset type names from the nested category tree."""
+    return [
+        asset_type["name"]
+        for category in data
+        for sub_category in category.get("subCategories", [])
+        for asset_type in sub_category.get("assetTypes", [])
+    ]
+
+
+@pytest.mark.django_db
+def test_asset_types_map_wide_returns_all(
+    scenario,
+    asset_types_for_scenario,  # noqa: ARG001
+    assets_for_scenario,  # noqa: ARG001
+    client,
+):
+    """Test that map-wide (no focus_area_id) returns all asset types."""
+    response = client.get(f"/api/scenarios/{scenario.id}/asset-types/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    assert "Rail Stations" in names
+    assert "Hospitals" in names
+
+
+@pytest.mark.django_db
+def test_asset_types_includes_datasource_id(
+    scenario,
+    asset_types_for_scenario,  # noqa: ARG001
+    assets_for_scenario,  # noqa: ARG001
+    client,
+):
+    """Test that asset types include datasourceId in response."""
+    response = client.get(f"/api/scenarios/{scenario.id}/asset-types/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    rail_type = find_asset_type_in_tree(data, "Rail Stations")
+    assert rail_type is not None
+    assert "datasourceId" in rail_type
+    assert rail_type["datasourceId"] is not None
+
+
+@pytest.mark.django_db
+def test_asset_types_focus_area_filters_by_geometry(
+    scenario,
+    asset_types_for_scenario,
+    focus_area,
+    client,
+):
+    """Test that focus area only returns asset types with assets in that area."""
+    # Create assets - only rail inside, only hospital outside
+    rail_type = asset_types_for_scenario["rail"]
+    hospital_type = asset_types_for_scenario["hospital"]
+
+    Asset.objects.create(
+        id=uuid.uuid4(),
+        external_id=uuid.uuid4(),
+        name="Rail Inside Only",
+        type=rail_type,
+        geom=Point(0.5, 0.5),  # Inside focus area (0,0 to 1,1)
+    )
+    Asset.objects.create(
+        id=uuid.uuid4(),
+        external_id=uuid.uuid4(),
+        name="Hospital Outside Only",
+        type=hospital_type,
+        geom=Point(5.0, 5.0),  # Outside focus area
+    )
+
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/asset-types/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    assert "Rail Stations" in names
+    assert "Hospitals" not in names
+
+
+@pytest.mark.django_db
+def test_asset_types_focus_area_returns_both_when_assets_in_area(
+    scenario,
+    asset_types_for_scenario,  # noqa: ARG001
+    assets_for_scenario,  # noqa: ARG001  - creates assets inside and outside
+    focus_area,
+    client,
+):
+    """Test focus area returns both types when both have assets inside."""
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/asset-types/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    # Both rail_inside and hospital_inside exist at (0.5, 0.5) inside focus area
+    assert "Rail Stations" in names
+    assert "Hospitals" in names
+
+
+@pytest.mark.django_db
+def test_asset_types_focus_area_empty_when_no_assets(
+    scenario,
+    asset_types_for_scenario,  # noqa: ARG001
+    focus_area,
+    client,
+):
+    """Test focus area returns empty when no assets in that area."""
+    # No assets created, so nothing should match
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/asset-types/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    assert len(names) == 0
+
+
+@pytest.mark.django_db
+def test_asset_types_focus_area_invalid_returns_404(scenario, client):
+    """Test that invalid focus_area_id returns 404."""
+    fake_focus_area_id = uuid.uuid4()
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/asset-types/?focus_area_id={fake_focus_area_id}"
+    )
+    assert response.status_code == http_not_found

--- a/backend/vista-python-api/src/api/tests/views/test_visible_asset_types.py
+++ b/backend/vista-python-api/src/api/tests/views/test_visible_asset_types.py
@@ -4,9 +4,10 @@ import json
 import uuid
 
 import pytest
-from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import GEOSGeometry, Point
 
 from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset import Asset
 from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
 
 http_success_code = 200
@@ -212,6 +213,15 @@ def test_scenario_asset_types_after_enable(scenario, asset_type, client):
 @pytest.mark.django_db
 def test_scenario_asset_types_with_focus_area(scenario, asset_type, focus_area, client):
     """Test getting visibility for specific focus area."""
+    # Create an asset inside the focus area bounds so the asset type is returned
+    Asset.objects.create(
+        id=uuid.uuid4(),
+        external_id=uuid.uuid4(),
+        name="Test Asset Inside",
+        type=asset_type,
+        geom=Point(0.5, 0.5),  # Inside focus area (0,0 to 1,1)
+    )
+
     client.put(
         f"/api/scenarios/{scenario.id}/visible-asset-types/",
         data=json.dumps(
@@ -340,3 +350,80 @@ def test_disable_focus_area_does_not_affect_map_wide(scenario, asset_type, focus
         focus_area__isnull=True,
         asset_type=asset_type,
     ).exists()
+
+
+@pytest.mark.django_db
+def test_delete_clears_all_map_wide_visibility(scenario, asset_type, client):
+    """Test DELETE clears all map-wide visibility."""
+    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    VisibleAsset.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area=None,
+        asset_type=asset_type,
+    )
+
+    response = client.delete(f"/api/scenarios/{scenario.id}/visible-asset-types/")
+
+    assert response.status_code == http_success_code, f"Response: {response.content}"
+    data = response.json()
+
+    assert data["success"] is True
+    assert not VisibleAsset.objects.filter(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area__isnull=True,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_delete_clears_focus_area_visibility(scenario, asset_type, focus_area, client):
+    """Test DELETE with focus_area_id clears only that focus area's visibility."""
+    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    # Create visibility for both map-wide and focus area
+    VisibleAsset.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area=None,
+        asset_type=asset_type,
+    )
+    VisibleAsset.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area=focus_area,
+        asset_type=asset_type,
+    )
+
+    response = client.delete(
+        f"/api/scenarios/{scenario.id}/visible-asset-types/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    assert data["success"] is True
+
+    # Focus area visibility should be deleted
+    assert not VisibleAsset.objects.filter(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area=focus_area,
+    ).exists()
+
+    # Map-wide visibility should still exist
+    assert VisibleAsset.objects.filter(
+        scenario=scenario,
+        user_id=mock_user_id,
+        focus_area__isnull=True,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_delete_with_no_visible_assets(scenario, client):
+    """Test DELETE succeeds even when nothing to delete."""
+    response = client.delete(f"/api/scenarios/{scenario.id}/visible-asset-types/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    assert data["success"] is True

--- a/backend/vista-python-api/src/api/views/scenario_assets.py
+++ b/backend/vista-python-api/src/api/views/scenario_assets.py
@@ -1,13 +1,13 @@
 """Views for scenario-scoped asset operations."""
 
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.models import FocusArea, Scenario, VisibleAsset
 from api.models.asset import Asset
-from api.models.asset_type import AssetCategory
+from api.models.asset_type import AssetType
 from api.serializers import ScenarioAssetSerializer
 from api.utils.auth import get_user_id_from_request
 
@@ -16,13 +16,18 @@ class ScenarioAssetTypesView(APIView):
     """View for listing asset types with visibility status for a scenario."""
 
     def get(self, request, scenario_id):
-        """List all asset categories with nested subcategories and asset types.
+        """List asset categories with nested subcategories and asset types.
 
         Each asset type includes isActive indicating visibility for the user.
 
+        When focus_area_id is provided, only returns asset types that have at
+        least one asset within that focus area's bounds. When omitted (map-wide),
+        returns all asset types.
+
         Query params:
             focus_area_id: Optional UUID. If provided, returns visibility status
-                for that specific focus area. If omitted, returns map-wide
+                for that specific focus area and filters to only asset types
+                with assets in that area. If omitted, returns map-wide
                 (global) visibility status where focus_area is NULL.
         """
         get_object_or_404(Scenario, id=scenario_id)
@@ -42,29 +47,62 @@ class ScenarioAssetTypesView(APIView):
 
         visible_asset_type_ids = set(visible_query.values_list("asset_type_id", flat=True))
 
-        categories = AssetCategory.objects.prefetch_related("sub_categories__asset_types").all()
+        asset_types_query = AssetType.objects.select_related(
+            "sub_category_id__category_id", "data_source_id"
+        )
+
+        if focus_area_id:
+            focus_area = get_object_or_404(
+                FocusArea, id=focus_area_id, scenario_id=scenario_id, user_id=user_id
+            )
+            # Filter to only asset types that have at least one asset in the focus area
+            asset_types_query = asset_types_query.filter(
+                Exists(
+                    Asset.objects.filter(type_id=OuterRef("pk"), geom__within=focus_area.geometry)
+                )
+            )
+
+        asset_types = asset_types_query.order_by(
+            "sub_category_id__category_id__name", "sub_category_id__name", "name"
+        )
+
+        categories_dict = {}
+        for asset_type in asset_types:
+            sub_cat = asset_type.sub_category_id
+            cat = sub_cat.category_id
+            datasource_id = asset_type.data_source_id_id
+
+            if cat.id not in categories_dict:
+                categories_dict[cat.id] = {
+                    "id": str(cat.id),
+                    "name": cat.name,
+                    "subCategories": {},
+                }
+
+            cat_data = categories_dict[cat.id]
+            if sub_cat.id not in cat_data["subCategories"]:
+                cat_data["subCategories"][sub_cat.id] = {
+                    "id": str(sub_cat.id),
+                    "name": sub_cat.name,
+                    "assetTypes": [],
+                }
+
+            cat_data["subCategories"][sub_cat.id]["assetTypes"].append(
+                {
+                    "id": str(asset_type.id),
+                    "name": asset_type.name,
+                    "isActive": asset_type.id in visible_asset_type_ids,
+                    "datasourceId": str(datasource_id) if datasource_id else None,
+                }
+            )
 
         result = [
             {
-                "id": str(category.id),
-                "name": category.name,
-                "subCategories": [
-                    {
-                        "id": str(sub_category.id),
-                        "name": sub_category.name,
-                        "assetTypes": [
-                            {
-                                "id": str(asset_type.id),
-                                "name": asset_type.name,
-                                "isActive": asset_type.id in visible_asset_type_ids,
-                            }
-                            for asset_type in sub_category.asset_types.all()
-                        ],
-                    }
-                    for sub_category in category.sub_categories.all()
-                ],
+                "id": cat_data["id"],
+                "name": cat_data["name"],
+                "subCategories": list(cat_data["subCategories"].values()),
             }
-            for category in categories
+            for cat_data in categories_dict.values()
         ]
 
         return Response(result)

--- a/backend/vista-python-api/src/api/views/visible_asset_types.py
+++ b/backend/vista-python-api/src/api/views/visible_asset_types.py
@@ -66,3 +66,31 @@ class VisibleAssetTypeView(APIView):
         response_serializer = VisibleAssetTypeResponseSerializer(data=response_data)
         response_serializer.is_valid()
         return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, scenario_id=None):
+        """Clear all visibility settings for a focus area or map-wide.
+
+        If focus_area_id query param is provided, clears visibility for that
+        specific focus area. Otherwise, clears map-wide visibility.
+        """
+        scenario = get_object_or_404(Scenario, id=scenario_id, is_active=True)
+        user_id = get_user_id_from_request(request)
+
+        focus_area_id = request.query_params.get("focus_area_id")
+
+        query = VisibleAsset.objects.filter(
+            scenario=scenario,
+            user_id=user_id,
+        )
+
+        if focus_area_id:
+            focus_area = get_object_or_404(
+                FocusArea, id=focus_area_id, scenario=scenario, user_id=user_id
+            )
+            query = query.filter(focus_area=focus_area)
+        else:
+            query = query.filter(focus_area__isnull=True)
+
+        query.delete()
+
+        return Response({"success": True}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

We need to filter the list to only what is available and display extra info.
https://ndtp.atlassian.net/browse/DPAV-1988

## Description

- Updates the asset-types endpoint to filter to available types only that would be visible within the focus area.
- Adds the dataSourceId to the asset types for frontend to display info
- Adds DELETE endpoint for asset-types to clear all visible assets in one request

## How Has This Been Tested?

Manually and unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
