### PR TITLE
feat(DPAV-1978): Add back the RadiusDialog draw circle feature

### DIFF
--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { Box } from '@mui/material';
 import type { MapRef, ViewStateChangeEvent } from 'react-map-gl/maplibre';
+import type { MapMouseEvent } from 'maplibre-gl';
 import Map, { Marker } from 'react-map-gl/maplibre';
 import { useQuery } from '@tanstack/react-query';
 
@@ -15,6 +16,7 @@ import AssetLayers from './AssetLayers';
 import ExposureLayers from './ExposureLayers';
 import UtilitiesLayers from './UtilitiesLayers';
 import FocusAreaMask from './FocusAreaMask';
+import RadiusDialog from './RadiusDialog';
 import useMapboxDraw from './hooks/useMapboxDraw';
 import useFocusAreas from './hooks/useFocusAreas';
 import { usePreloadAssetIcons } from './hooks/usePreloadAssetIcons';
@@ -43,13 +45,15 @@ const MapView = () => {
     const [roadRouteEnd, setRoadRouteEnd] = useState<{ lat: number; lng: number } | null>(null);
     const [roadRouteVehicle, setRoadRouteVehicle] = useState<RoadRouteInputParams['vehicle']>('Car');
     const [positionSelectionMode, setPositionSelectionMode] = useState<'start' | 'end' | null>(null);
+    const [pendingCircleCenter, setPendingCircleCenter] = useState<[number, number] | null>(null);
+    const [radiusDialogOpen, setRadiusDialogOpen] = useState(false);
 
     const drawRef = useMapboxDraw(mapRef, mapReady);
     const { data: activeScenario } = useActiveScenario();
     const scenarioId = activeScenario?.id;
     const iconMap = useAssetTypeIcons();
 
-    const { focusAreas, isDrawing, startDrawing } = useFocusAreas({
+    const { focusAreas, isDrawing, drawingMode, startDrawing, createCircleAtPoint } = useFocusAreas({
         scenarioId,
         mapRef,
         drawRef,
@@ -211,12 +215,35 @@ const MapView = () => {
         }
 
         const previousCursor = canvas.style.cursor;
-        canvas.style.cursor = positionSelectionMode ? 'crosshair' : '';
+        canvas.style.cursor = positionSelectionMode || drawingMode === 'circle' ? 'crosshair' : '';
 
         return () => {
             canvas.style.cursor = previousCursor;
         };
-    }, [positionSelectionMode]);
+    }, [positionSelectionMode, drawingMode]);
+
+    // Show radius dialog on click when drawing circles
+    useEffect(() => {
+        if (!mapReady || drawingMode !== 'circle') {
+            return;
+        }
+
+        const map = mapRef.current?.getMap();
+        if (!map) {
+            return;
+        }
+
+        const handleClick = (e: MapMouseEvent) => {
+            setPendingCircleCenter([e.lngLat.lng, e.lngLat.lat]);
+            setRadiusDialogOpen(true);
+        };
+
+        map.on('click', handleClick);
+
+        return () => {
+            map.off('click', handleClick);
+        };
+    }, [mapReady, drawingMode]);
 
     const transformRequest = useCallback((url: string) => {
         let transformedUrl = url;
@@ -362,7 +389,7 @@ const MapView = () => {
                     onClick={handleMapClick}
                     mapStyle={mapStyle}
                     maxBounds={MAP_VIEW_BOUNDS}
-                    style={{ width: '100%', height: '100%', cursor: positionSelectionMode ? 'crosshair' : 'grab' }}
+                    style={{ width: '100%', height: '100%', cursor: positionSelectionMode || drawingMode === 'circle' ? 'crosshair' : 'grab' }}
                     onLoad={handleMapLoad}
                     transformRequest={transformRequest}
                     styleDiffing
@@ -447,6 +474,21 @@ const MapView = () => {
                     viewState={viewState}
                 />
             </Box>
+
+            <RadiusDialog
+                open={radiusDialogOpen}
+                onClose={() => {
+                    setRadiusDialogOpen(false);
+                    setPendingCircleCenter(null);
+                }}
+                onConfirm={(radiusKm) => {
+                    if (pendingCircleCenter) {
+                        createCircleAtPoint(pendingCircleCenter, radiusKm);
+                    }
+                    setRadiusDialogOpen(false);
+                    setPendingCircleCenter(null);
+                }}
+            />
         </Box>
     );
 };

--- a/frontend/src/components/map-v2/RadiusDialog.test.tsx
+++ b/frontend/src/components/map-v2/RadiusDialog.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import RadiusDialog from './RadiusDialog';
+
+describe('RadiusDialog', () => {
+    const defaultProps = {
+        open: true,
+        onClose: vi.fn(),
+        onConfirm: vi.fn(),
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('rendering', () => {
+        it('renders when open is true', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByRole('dialog')).toBeInTheDocument();
+            expect(screen.getByText('Enter circle radius')).toBeInTheDocument();
+        });
+
+        it('does not render when open is false', () => {
+            render(<RadiusDialog {...defaultProps} open={false} />);
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        it('renders input field with correct label', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByLabelText('Radius (km)')).toBeInTheDocument();
+        });
+
+        it('renders helper text when no error', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            // Helper text shows when error is empty string (falsy)
+            expect(screen.getByText('Enter the radius of the circle in kilometers')).toBeInTheDocument();
+        });
+
+        it('renders Cancel and Confirm buttons', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+        });
+
+        it('renders close button in title', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByRole('button', { name: 'close' })).toBeInTheDocument();
+        });
+
+        it('has Confirm button disabled initially', () => {
+            render(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+        });
+    });
+
+    describe('input validation', () => {
+        it('enables Confirm button when valid number is entered', async () => {
+            const user = userEvent.setup();
+            render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+        });
+
+        it('shows error for negative numbers', async () => {
+            const user = userEvent.setup();
+            render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '-5');
+
+            expect(screen.getByText('Please enter a valid positive number')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+        });
+
+        it('shows error for zero', async () => {
+            const user = userEvent.setup();
+            render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '0');
+
+            expect(screen.getByText('Please enter a valid positive number')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+        });
+
+        it('accepts decimal numbers', async () => {
+            const user = userEvent.setup();
+            render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '2.5');
+
+            expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+            expect(screen.queryByText('Please enter a valid positive number')).not.toBeInTheDocument();
+        });
+
+        it('clears error when input is cleared', async () => {
+            const user = userEvent.setup();
+            render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '-5');
+            expect(screen.getByText('Please enter a valid positive number')).toBeInTheDocument();
+
+            await user.clear(input);
+            expect(screen.queryByText('Please enter a valid positive number')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('confirm action', () => {
+        it('calls onConfirm with radius value when Confirm button is clicked', async () => {
+            const user = userEvent.setup();
+            const onConfirm = vi.fn();
+            render(<RadiusDialog {...defaultProps} onConfirm={onConfirm} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+            expect(onConfirm).toHaveBeenCalledWith(5);
+        });
+
+        it('calls onClose after confirming', async () => {
+            const user = userEvent.setup();
+            const onClose = vi.fn();
+            render(<RadiusDialog {...defaultProps} onClose={onClose} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it('clears input after confirming', async () => {
+            const user = userEvent.setup();
+            const { rerender } = render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+            rerender(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByLabelText('Radius (km)')).toHaveValue(null);
+        });
+
+        it('calls onConfirm with decimal value', async () => {
+            const user = userEvent.setup();
+            const onConfirm = vi.fn();
+            render(<RadiusDialog {...defaultProps} onConfirm={onConfirm} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '2.5');
+            await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+            expect(onConfirm).toHaveBeenCalledWith(2.5);
+        });
+    });
+
+    describe('cancel action', () => {
+        it('calls onClose when Cancel button is clicked', async () => {
+            const user = userEvent.setup();
+            const onClose = vi.fn();
+            render(<RadiusDialog {...defaultProps} onClose={onClose} />);
+
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it('calls onClose when close icon button is clicked', async () => {
+            const user = userEvent.setup();
+            const onClose = vi.fn();
+            render(<RadiusDialog {...defaultProps} onClose={onClose} />);
+
+            await user.click(screen.getByRole('button', { name: 'close' }));
+
+            expect(onClose).toHaveBeenCalled();
+        });
+
+        it('clears input when cancelled', async () => {
+            const user = userEvent.setup();
+            const { rerender } = render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            rerender(<RadiusDialog {...defaultProps} />);
+            expect(screen.getByLabelText('Radius (km)')).toHaveValue(null);
+        });
+
+        it('clears error when cancelled', async () => {
+            const user = userEvent.setup();
+            const { rerender } = render(<RadiusDialog {...defaultProps} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '-5');
+            expect(screen.getByText('Please enter a valid positive number')).toBeInTheDocument();
+
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            rerender(<RadiusDialog {...defaultProps} />);
+            expect(screen.queryByText('Please enter a valid positive number')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('keyboard interactions', () => {
+        it('confirms on Enter key when input is valid', async () => {
+            const user = userEvent.setup();
+            const onConfirm = vi.fn();
+            render(<RadiusDialog {...defaultProps} onConfirm={onConfirm} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(onConfirm).toHaveBeenCalledWith(5);
+        });
+
+        it('does not confirm on Enter key when input is empty', async () => {
+            const onConfirm = vi.fn();
+            render(<RadiusDialog {...defaultProps} onConfirm={onConfirm} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(onConfirm).not.toHaveBeenCalled();
+        });
+
+        it('does not confirm on Enter key when input has error', async () => {
+            const user = userEvent.setup();
+            const onConfirm = vi.fn();
+            render(<RadiusDialog {...defaultProps} onConfirm={onConfirm} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '-5');
+            fireEvent.keyDown(input, { key: 'Enter' });
+
+            expect(onConfirm).not.toHaveBeenCalled();
+        });
+
+        it('cancels on Escape key', async () => {
+            const user = userEvent.setup();
+            const onClose = vi.fn();
+            render(<RadiusDialog {...defaultProps} onClose={onClose} />);
+
+            const input = screen.getByLabelText('Radius (km)');
+            await user.type(input, '5');
+            fireEvent.keyDown(input, { key: 'Escape' });
+
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+
+    describe('focus behavior', () => {
+        it('auto-focuses the input field when opened', async () => {
+            render(<RadiusDialog {...defaultProps} />);
+            const input = screen.getByLabelText('Radius (km)');
+            await vi.waitFor(() => {
+                expect(input).toHaveFocus();
+            });
+        });
+    });
+});

--- a/frontend/src/components/map-v2/RadiusDialog.tsx
+++ b/frontend/src/components/map-v2/RadiusDialog.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, IconButton, Box } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface RadiusDialogProps {
+    readonly open: boolean;
+    readonly onClose: () => void;
+    readonly onConfirm: (radius: number) => void;
+}
+
+export default function RadiusDialog({ open, onClose, onConfirm }: RadiusDialogProps) {
+    const [radius, setRadius] = useState<string>('');
+    const [error, setError] = useState<string>('');
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (open) {
+            setTimeout(() => {
+                inputRef.current?.focus();
+            }, 0);
+        }
+    }, [open]);
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = event.target.value;
+        setRadius(value);
+
+        const numValue = Number.parseFloat(value);
+        if (value === '') {
+            setError('');
+        } else if (Number.isNaN(numValue) || numValue <= 0) {
+            setError('Please enter a valid positive number');
+        } else {
+            setError('');
+        }
+    };
+
+    const handleConfirm = () => {
+        const numRadius = Number.parseFloat(radius);
+        if (!Number.isNaN(numRadius) && numRadius > 0) {
+            onConfirm(numRadius);
+            setRadius('');
+            setError('');
+            onClose();
+        }
+    };
+
+    const handleCancel = () => {
+        setRadius('');
+        setError('');
+        onClose();
+    };
+
+    const handleKeyPress = (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter' && !error && radius !== '') {
+            handleConfirm();
+        } else if (event.key === 'Escape') {
+            handleCancel();
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={handleCancel} aria-labelledby="radius-dialog-title" maxWidth="sm" fullWidth>
+            <DialogTitle id="radius-dialog-title">
+                Enter circle radius
+                <IconButton
+                    aria-label="close"
+                    onClick={handleCancel}
+                    sx={{
+                        position: 'absolute',
+                        right: 8,
+                        top: 8,
+                        color: (theme) => theme.palette.grey[500],
+                    }}
+                >
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent>
+                <Box sx={{ mt: 1 }}>
+                    <TextField
+                        inputRef={inputRef}
+                        fullWidth
+                        label="Radius (km)"
+                        value={radius}
+                        onChange={handleInputChange}
+                        onKeyDown={handleKeyPress}
+                        error={!!error}
+                        helperText={error || 'Enter the radius of the circle in kilometers'}
+                        variant="outlined"
+                        type="number"
+                        slotProps={{ htmlInput: { step: '0.1', min: '0.1' } }}
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={handleCancel} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={handleConfirm} color="primary" variant="contained" disabled={!!error || radius === ''}>
+                    Confirm
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/frontend/src/components/map-v2/hooks/useFocusAreas.test.tsx
+++ b/frontend/src/components/map-v2/hooks/useFocusAreas.test.tsx
@@ -125,6 +125,22 @@ describe('useFocusAreas', () => {
             expect(result.current.isDrawing).toBe(false);
         });
 
+        it('returns drawingMode as null initially', () => {
+            const mockMap = createMockMap();
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: createMockDrawRef() as any,
+                        mapReady: false,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            expect(result.current.drawingMode).toBe(null);
+        });
+
         it('returns startDrawing function', () => {
             const mockMap = createMockMap();
             const { result } = renderHook(
@@ -140,10 +156,26 @@ describe('useFocusAreas', () => {
 
             expect(typeof result.current.startDrawing).toBe('function');
         });
+
+        it('returns createCircleAtPoint function', () => {
+            const mockMap = createMockMap();
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: createMockDrawRef() as any,
+                        mapReady: false,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            expect(typeof result.current.createCircleAtPoint).toBe('function');
+        });
     });
 
     describe('startDrawing', () => {
-        it('sets isDrawing to true when called with "polygon"', () => {
+        it('sets isDrawing to true and drawingMode to "polygon" when called with "polygon"', () => {
             const mockMap = createMockMap();
             const mockDrawRef = createMockDrawRef();
             const { result } = renderHook(
@@ -162,10 +194,11 @@ describe('useFocusAreas', () => {
             });
 
             expect(result.current.isDrawing).toBe(true);
+            expect(result.current.drawingMode).toBe('polygon');
             expect(mockDrawRef.current.changeMode).toHaveBeenCalledWith('draw_polygon');
         });
 
-        it('sets isDrawing to true when called with "circle"', () => {
+        it('sets isDrawing to true and drawingMode to "circle" when called with "circle"', () => {
             const mockMap = createMockMap();
             const mockDrawRef = createMockDrawRef();
             const { result } = renderHook(
@@ -184,6 +217,7 @@ describe('useFocusAreas', () => {
             });
 
             expect(result.current.isDrawing).toBe(true);
+            expect(result.current.drawingMode).toBe('circle');
             expect(mockDrawRef.current.changeMode).toHaveBeenCalledWith('drag_circle');
         });
 
@@ -205,6 +239,7 @@ describe('useFocusAreas', () => {
             });
 
             expect(result.current.isDrawing).toBe(false);
+            expect(result.current.drawingMode).toBe(null);
         });
     });
 
@@ -713,6 +748,171 @@ describe('useFocusAreas', () => {
             await waitFor(() => {
                 expect(mockedFetchFocusAreas).toHaveBeenCalledWith('scenario-2');
             });
+        });
+    });
+
+    describe('createCircleAtPoint', () => {
+        it('creates a circle geometry and calls mutation', async () => {
+            mockedCreateFocusArea.mockResolvedValue(createMockFocusArea({ id: 'new-circle' }));
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            act(() => {
+                result.current.startDrawing('circle');
+            });
+
+            expect(result.current.isDrawing).toBe(true);
+            expect(result.current.drawingMode).toBe('circle');
+
+            act(() => {
+                result.current.createCircleAtPoint([-1.4, 50.67], 5);
+            });
+
+            expect(result.current.isDrawing).toBe(false);
+            expect(result.current.drawingMode).toBe(null);
+            expect(mockDrawRef.current.changeMode).toHaveBeenCalledWith('simple_select');
+
+            await waitFor(() => {
+                expect(mockedCreateFocusArea).toHaveBeenCalledWith('scenario-123', {
+                    geometry: expect.objectContaining({
+                        type: 'Polygon',
+                    }),
+                    isActive: true,
+                });
+            });
+        });
+
+        it('resets drawing state when called', () => {
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            act(() => {
+                result.current.startDrawing('circle');
+            });
+
+            expect(result.current.isDrawing).toBe(true);
+            expect(result.current.drawingMode).toBe('circle');
+
+            act(() => {
+                result.current.createCircleAtPoint([-1.4, 50.67], 2.5);
+            });
+
+            expect(result.current.isDrawing).toBe(false);
+            expect(result.current.drawingMode).toBe(null);
+        });
+    });
+
+    describe('drawingMode reset', () => {
+        it('resets drawingMode to null when draw.create event fires', async () => {
+            mockedCreateFocusArea.mockResolvedValue(createMockFocusArea({ id: 'new-fa' }));
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            let createHandler: (event: { features: Feature[] }) => void;
+
+            mockMap.on.mockImplementation((event: string, handler: any) => {
+                if (event === 'draw.create') {
+                    createHandler = handler;
+                }
+            });
+
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockMap.on).toHaveBeenCalled();
+            });
+
+            act(() => {
+                result.current.startDrawing('polygon');
+            });
+
+            expect(result.current.drawingMode).toBe('polygon');
+
+            const mockFeature: Feature = {
+                type: 'Feature',
+                id: 'temp-123',
+                properties: {},
+                geometry: mockGeometry,
+            };
+
+            act(() => {
+                createHandler({ features: [mockFeature] });
+            });
+
+            expect(result.current.drawingMode).toBe(null);
+        });
+
+        it('resets drawingMode to null when mode changes to simple_select', async () => {
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            let modeChangeHandler: () => void;
+
+            mockMap.on.mockImplementation((event: string, handler: any) => {
+                if (event === 'draw.modechange') {
+                    modeChangeHandler = handler;
+                }
+            });
+
+            mockDrawRef.current.getMode.mockReturnValue('simple_select');
+
+            const { result } = renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockMap.on).toHaveBeenCalled();
+            });
+
+            act(() => {
+                result.current.startDrawing('circle');
+            });
+
+            expect(result.current.drawingMode).toBe('circle');
+
+            act(() => {
+                modeChangeHandler();
+            });
+
+            expect(result.current.drawingMode).toBe(null);
         });
     });
 });

--- a/frontend/src/components/map-v2/hooks/useFocusAreas.ts
+++ b/frontend/src/components/map-v2/hooks/useFocusAreas.ts
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useEffect, useRef, useState, useCallback, type RefObject } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { Feature } from 'geojson';
 import type MapboxDraw from '@mapbox/mapbox-gl-draw';
 import type { MapRef } from 'react-map-gl/maplibre';
+import { circle } from '@turf/turf';
 import useFocusAreaMutations from './useFocusAreaMutations';
 import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
 
@@ -16,7 +17,7 @@ type UseFocusAreasOptions = {
 const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasOptions) => {
     const loadedFocusAreaIdsRef = useRef<Set<string>>(new Set());
     const focusAreasRef = useRef<FocusArea[] | undefined>(undefined);
-    const [isDrawing, setIsDrawing] = useState(false);
+    const [drawingMode, setDrawingMode] = useState<'circle' | 'polygon' | null>(null);
 
     const { data: focusAreas } = useQuery({
         queryKey: ['focusAreas', scenarioId],
@@ -102,7 +103,7 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
         const map = mapRef.current.getMap();
 
         const handleDrawCreate = (event: { features: Feature[] }) => {
-            setIsDrawing(false);
+            setDrawingMode(null);
 
             if (!scenarioId || event.features.length === 0) {
                 return;
@@ -119,7 +120,7 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
         const handleModeChange = () => {
             const currentMode = drawRef.current?.getMode();
             if (currentMode === 'simple_select') {
-                setIsDrawing(false);
+                setDrawingMode(null);
             }
         };
 
@@ -168,13 +169,29 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
         } else {
             drawRef.current.changeMode('draw_polygon');
         }
-        setIsDrawing(true);
+        setDrawingMode(mode);
     };
+
+    const createCircleAtPoint = useCallback(
+        (center: [number, number], radiusKm: number) => {
+            const circleFeature = circle(center, radiusKm, { units: 'kilometers' });
+
+            if (drawRef.current) {
+                drawRef.current.changeMode('simple_select');
+            }
+
+            createMutateRef.current(circleFeature.geometry);
+            setDrawingMode(null);
+        },
+        [drawRef],
+    );
 
     return {
         focusAreas,
-        isDrawing,
+        isDrawing: drawingMode !== null,
+        drawingMode,
         startDrawing,
+        createCircleAtPoint,
     };
 };
 

--- a/frontend/src/components/map-v2/panels/AssetsView.test.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.test.tsx
@@ -213,11 +213,11 @@ describe('AssetsView', () => {
     });
 
     describe('Focus Area Selection', () => {
-        it('shows Map wide as default selection', async () => {
+        it('shows Map-wide as default selection', async () => {
             setupMocks();
             renderWithProviders(<AssetsView {...defaultProps} />);
             await waitFor(() => {
-                expect(screen.getByText('Map wide')).toBeInTheDocument();
+                expect(screen.getByText('Map-wide')).toBeInTheDocument();
             });
         });
 
@@ -243,7 +243,7 @@ describe('AssetsView', () => {
                 { timeout: 3000 },
             );
 
-            expect(screen.getByRole('option', { name: 'Map wide' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Map-wide' })).toBeInTheDocument();
             expect(screen.getByRole('option', { name: 'Area 1' })).toBeInTheDocument();
         });
 

--- a/frontend/src/components/map-v2/panels/AssetsView.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.tsx
@@ -300,7 +300,7 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
                         label="Select visible focus area"
                         disabled={isLoadingFocusAreas}
                     >
-                        <MenuItem value={MAP_WIDE_VALUE}>Map wide</MenuItem>
+                        <MenuItem value={MAP_WIDE_VALUE}>Map-wide</MenuItem>
                         {focusAreas?.map((fa: FocusArea) => (
                             <MenuItem key={fa.id} value={fa.id} disabled={!fa.isActive}>
                                 {fa.name}

--- a/frontend/src/vendor/mapbox-gl-draw-circle/lib/modes/DragCircleMode.js
+++ b/frontend/src/vendor/mapbox-gl-draw-circle/lib/modes/DragCircleMode.js
@@ -67,6 +67,12 @@ DragCircleMode.onClick = DragCircleMode.onTap = function (state, _e) {
 DragCircleMode.toDisplayFeatures = function (state, geojson, display) {
     const isActivePolygon = geojson.properties.id === state.polygon.id;
     geojson.properties.active = isActivePolygon ? MapboxDraw.constants.activeStates.ACTIVE : MapboxDraw.constants.activeStates.INACTIVE;
+
+    // don't try render invalid geometry, breaks other features
+    if (isActivePolygon && geojson.geometry.coordinates[0].length < 3) {
+        return;
+    }
+
     return display(geojson);
 };
 


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-1978

Add back the previous click on point to add a circle by radius to the map drawing for the new map implementation and focus areas.

## Description

- Brings back the old modal and fixes an issue with the custom mode attempting to display an invalid geometry.
- Fixes Map Wide -> Map-wide for consistency

## How Has This Been Tested?

Locally, tests

## Screenshots (if appropriate):

<img width="724" height="304" alt="Screenshot 2025-12-11 at 15 26 03" src="https://github.com/user-attachments/assets/5aa0d310-8f3a-4af0-a020-e88b787e19c9" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
