### PR TITLE
feat(DPAV01986): remember user choices for active exposure layers and support focus areas

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /vista-python-api/core
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y build-essential \
     libstdc++6 \
+    gdal-bin \
+    libgdal-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install poetry globally

--- a/frontend/dev/docker-compose.yaml
+++ b/frontend/dev/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     zookeeper:
         container_name: vista-zookeeper
@@ -56,16 +55,16 @@ services:
                 condition: service_healthy
         volumes:
             - ./data/ontology.ttl:/work/ontology.ttl
-    api:
-        container_name: smart-cache-vista-api
-        image: smart-cache-vista-api
-        ports:
-            - 4001:4001
-        environment:
-            JENA_URL: secure-agent-graph
-            JENA_PORT: 3030
-            PORT: 4001
-            JENA_DATASET: knowledge
+    # api:
+    #     container_name: smart-cache-vista-api
+    #     image: smart-cache-vista-api
+    #     ports:
+    #         - 4001:4001
+    #     environment:
+    #         JENA_URL: secure-agent-graph
+    #         JENA_PORT: 3030
+    #         PORT: 4001
+    #         JENA_DATASET: knowledge
     transparent-proxy:
         container_name: vista-transparent-proxy
         image: vista-transparent-proxy
@@ -79,7 +78,7 @@ services:
         depends_on:
             - secure-agent-graph
     postgres:
-        image: postgis/postgis:latest
+        image: postgis/postgis:16-3.4
         container_name: postgis
         environment:
             POSTGRES_USER: postgres
@@ -90,6 +89,7 @@ services:
     vista-python-api:
         container_name: vista-python-api
         image: vista-python-api
+        pull_policy: build
         env_file:
             - '../../backend/.env.docker'
         build:
@@ -99,6 +99,7 @@ services:
             - 8000:8000
     migrate-and-seed:
         image: vista-python-api
+        pull_policy: build
         command: ['/vista-python-api/src/api/db_setup.sh']
         env_file:
             - '../../backend/.env.docker'

--- a/frontend/src/api/exposure-layers.test.ts
+++ b/frontend/src/api/exposure-layers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Geometry } from 'geojson';
 
-import { fetchExposureLayers } from './exposure-layers';
+import { fetchExposureLayers, fetchExposureLayerGeometry, fetchExposureLayerVisibility, mergeGeometryWithVisibility } from './exposure-layers';
 
 vi.mock('@/config/app-config', () => ({
     default: {
@@ -14,262 +14,297 @@ vi.mock('@/config/app-config', () => ({
 describe('exposure-layers API', () => {
     let fetchMock: ReturnType<typeof vi.fn>;
 
+    const mockGeometry: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.4, 50.67],
+                [-1.4, 50.68],
+                [-1.39, 50.68],
+                [-1.39, 50.67],
+                [-1.4, 50.67],
+            ],
+        ],
+    };
+
+    const mockGeometry2: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.3, 50.66],
+                [-1.3, 50.67],
+                [-1.29, 50.67],
+                [-1.29, 50.66],
+                [-1.3, 50.66],
+            ],
+        ],
+    };
+
     beforeEach(() => {
         fetchMock = vi.fn();
-        globalThis.fetch = fetchMock as any;
+        globalThis.fetch = fetchMock as typeof fetch;
     });
 
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
-    describe('fetchExposureLayers', () => {
-        it('successfully fetches exposure layers with polygon geometry', async () => {
-            const mockGeometry: Geometry = {
-                type: 'Polygon',
-                coordinates: [
-                    [
-                        [-1.4, 50.67],
-                        [-1.4, 50.68],
-                        [-1.39, 50.68],
-                        [-1.39, 50.67],
-                        [-1.4, 50.67],
-                    ],
-                ],
-            };
-
+    describe('fetchExposureLayerGeometry', () => {
+        it('fetches geometry from exposurelayers endpoint', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
                 json: vi.fn().mockResolvedValue([
                     {
                         id: 'group-1',
                         name: 'Floods',
-                        exposureLayers: [
-                            {
-                                id: '35a910f3-f611-4096-ac0b-0928c5612e32',
-                                name: 'Test Layer 1',
-                                geometry: mockGeometry,
-                            },
-                        ],
+                        exposureLayers: [{ id: 'layer-1', name: 'Test Layer 1', geometry: mockGeometry }],
                     },
                 ]),
             });
 
-            const result = await fetchExposureLayers();
+            const result = await fetchExposureLayerGeometry();
 
-            expect(result.featureCollection.type).toBe('FeatureCollection');
-            expect(result.featureCollection.features).toHaveLength(1);
-            expect(result.featureCollection.features[0].id).toBe('35a910f3-f611-4096-ac0b-0928c5612e32');
-            expect(result.featureCollection.features[0].geometry.type).toBe('Polygon');
-            expect(result.featureCollection.features[0].properties?.name).toBe('Test Layer 1');
-            expect(result.featureCollection.features[0].properties?.groupId).toBe('group-1');
-            expect(result.featureCollection.features[0].properties?.groupName).toBe('Floods');
-            expect(result.groups).toHaveLength(1);
-            expect(result.groups[0].id).toBe('group-1');
-            expect(result.groups[0].name).toBe('Floods');
-            expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/ndtp-python/api/exposurelayers/'), {
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('group-1');
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/exposurelayers/', {
                 headers: { 'Content-Type': 'application/json' },
             });
-        });
-
-        it('successfully handles multipolygon geometry', async () => {
-            const mockGeometry: Geometry = {
-                type: 'MultiPolygon',
-                coordinates: [
-                    [
-                        [
-                            [-1.4, 50.67],
-                            [-1.4, 50.68],
-                            [-1.39, 50.68],
-                            [-1.39, 50.67],
-                            [-1.4, 50.67],
-                        ],
-                    ],
-                ],
-            };
-
-            fetchMock.mockResolvedValue({
-                ok: true,
-                json: vi.fn().mockResolvedValue([
-                    {
-                        id: 'group-1',
-                        name: 'Floods',
-                        exposureLayers: [
-                            {
-                                id: 'e34e3c22-a28f-45e5-99b5-a24b55ba875f',
-                                name: 'Test Layer 2',
-                                geometry: mockGeometry,
-                            },
-                        ],
-                    },
-                ]),
-            });
-
-            const result = await fetchExposureLayers();
-
-            expect(result.featureCollection.features).toHaveLength(1);
-            expect(result.featureCollection.features[0].geometry.type).toBe('MultiPolygon');
-        });
-
-        it('filters out layers with missing geometry', async () => {
-            const mockGeometry: Geometry = {
-                type: 'Polygon',
-                coordinates: [
-                    [
-                        [-1.4, 50.67],
-                        [-1.4, 50.68],
-                        [-1.39, 50.68],
-                        [-1.39, 50.67],
-                        [-1.4, 50.67],
-                    ],
-                ],
-            };
-
-            fetchMock.mockResolvedValue({
-                ok: true,
-                json: vi.fn().mockResolvedValue([
-                    {
-                        id: 'group-1',
-                        name: 'Floods',
-                        exposureLayers: [
-                            {
-                                id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-                                name: 'Valid Layer',
-                                geometry: mockGeometry,
-                            },
-                            {
-                                id: 'f9e8d7c6-b5a4-3210-9876-543210fedcba',
-                                name: 'Invalid Layer',
-                                geometry: null as any,
-                            },
-                        ],
-                    },
-                ]),
-            });
-
-            const result = await fetchExposureLayers();
-
-            expect(result.featureCollection.features).toHaveLength(1);
-            expect(result.featureCollection.features[0].id).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
-        });
-
-        it('handles multiple groups with multiple layers', async () => {
-            const mockGeometry1: Geometry = {
-                type: 'Polygon',
-                coordinates: [
-                    [
-                        [-1.4, 50.67],
-                        [-1.4, 50.68],
-                        [-1.39, 50.68],
-                        [-1.39, 50.67],
-                        [-1.4, 50.67],
-                    ],
-                ],
-            };
-
-            const mockGeometry2: Geometry = {
-                type: 'Polygon',
-                coordinates: [
-                    [
-                        [-1.3, 50.66],
-                        [-1.3, 50.67],
-                        [-1.29, 50.67],
-                        [-1.29, 50.66],
-                        [-1.3, 50.66],
-                    ],
-                ],
-            };
-
-            fetchMock.mockResolvedValue({
-                ok: true,
-                json: vi.fn().mockResolvedValue([
-                    {
-                        id: 'group-1',
-                        name: 'Floods',
-                        exposureLayers: [
-                            {
-                                id: 'layer-1',
-                                name: 'Test Layer 1',
-                                geometry: mockGeometry1,
-                            },
-                        ],
-                    },
-                    {
-                        id: 'group-2',
-                        name: 'Environmentally sensitive areas',
-                        exposureLayers: [
-                            {
-                                id: 'layer-2',
-                                name: 'Test Layer 2',
-                                geometry: mockGeometry2,
-                            },
-                        ],
-                    },
-                ]),
-            });
-
-            const result = await fetchExposureLayers();
-
-            expect(result.featureCollection.features).toHaveLength(2);
-            expect(result.groups).toHaveLength(2);
-            expect(result.groups[0].name).toBe('Floods');
-            expect(result.groups[1].name).toBe('Environmentally sensitive areas');
-            expect(result.featureCollection.features[0].properties?.groupName).toBe('Floods');
-            expect(result.featureCollection.features[1].properties?.groupName).toBe('Environmentally sensitive areas');
         });
 
         it('throws error when response is not ok', async () => {
             fetchMock.mockResolvedValue({
                 ok: false,
-                status: 500,
                 statusText: 'Internal Server Error',
             });
 
-            await expect(fetchExposureLayers()).rejects.toThrow('Failed to retrieve exposure layers: Internal Server Error');
+            await expect(fetchExposureLayerGeometry()).rejects.toThrow('Failed to retrieve exposure layer geometry: Internal Server Error');
+        });
+    });
+
+    describe('fetchExposureLayerVisibility', () => {
+        it('fetches visibility from scenario endpoint', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockResolvedValue([
+                    {
+                        id: 'group-1',
+                        name: 'Floods',
+                        exposureLayers: [{ id: 'layer-1', name: 'Test Layer 1', isActive: true }],
+                    },
+                ]),
+            });
+
+            const result = await fetchExposureLayerVisibility('scenario-1');
+
+            expect(result).toHaveLength(1);
+            expect(result[0].exposureLayers[0].isActive).toBe(true);
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/scenarios/scenario-1/exposure-layers/', {
+                headers: { 'Content-Type': 'application/json' },
+            });
         });
 
-        it('throws error on network failure', async () => {
-            fetchMock.mockRejectedValue(new Error('Network error'));
-
-            await expect(fetchExposureLayers()).rejects.toThrow('Network error');
-        });
-
-        it('handles empty groups array', async () => {
+        it('includes focus_area_id in query when provided', async () => {
             fetchMock.mockResolvedValue({
                 ok: true,
                 json: vi.fn().mockResolvedValue([]),
             });
 
-            const result = await fetchExposureLayers();
+            await fetchExposureLayerVisibility('scenario-1', 'focus-area-1');
+
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/scenarios/scenario-1/exposure-layers/?focus_area_id=focus-area-1', {
+                headers: { 'Content-Type': 'application/json' },
+            });
+        });
+
+        it('does not include focus_area_id when null', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockResolvedValue([]),
+            });
+
+            await fetchExposureLayerVisibility('scenario-1', null);
+
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/scenarios/scenario-1/exposure-layers/', {
+                headers: { 'Content-Type': 'application/json' },
+            });
+        });
+
+        it('throws error when response is not ok', async () => {
+            fetchMock.mockResolvedValue({
+                ok: false,
+                statusText: 'Internal Server Error',
+            });
+
+            await expect(fetchExposureLayerVisibility('scenario-1')).rejects.toThrow('Failed to retrieve exposure layer visibility: Internal Server Error');
+        });
+    });
+
+    describe('mergeGeometryWithVisibility', () => {
+        it('merges geometry and visibility data', () => {
+            const geometryData = [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: [
+                        { id: 'layer-1', name: 'Test Layer 1', geometry: mockGeometry },
+                        { id: 'layer-2', name: 'Test Layer 2', geometry: mockGeometry2 },
+                    ],
+                },
+            ];
+
+            const visibilityData = [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: [
+                        { id: 'layer-1', name: 'Test Layer 1', isActive: true },
+                        { id: 'layer-2', name: 'Test Layer 2', isActive: false },
+                    ],
+                },
+            ];
+
+            const result = mergeGeometryWithVisibility(geometryData, visibilityData);
+
+            expect(result.groups[0].exposureLayers[0].isActive).toBe(true);
+            expect(result.groups[0].exposureLayers[1].isActive).toBe(false);
+            expect(result.featureCollection.features[0].properties?.isActive).toBe(true);
+            expect(result.featureCollection.features[1].properties?.isActive).toBe(false);
+        });
+
+        it('defaults isActive to false when not in visibility data', () => {
+            const geometryData = [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: [{ id: 'layer-1', name: 'Test Layer 1', geometry: mockGeometry }],
+                },
+            ];
+
+            const visibilityData: typeof geometryData = [];
+
+            const result = mergeGeometryWithVisibility(geometryData, visibilityData);
+
+            expect(result.groups[0].exposureLayers[0].isActive).toBe(false);
+        });
+
+        it('filters out layers without geometry in featureCollection', () => {
+            const geometryData = [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: [
+                        { id: 'layer-1', name: 'Test Layer 1', geometry: mockGeometry },
+                        { id: 'layer-2', name: 'Test Layer 2', geometry: undefined },
+                    ],
+                },
+            ];
+
+            const visibilityData = [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: [
+                        { id: 'layer-1', name: 'Test Layer 1', isActive: true },
+                        { id: 'layer-2', name: 'Test Layer 2', isActive: true },
+                    ],
+                },
+            ];
+
+            const result = mergeGeometryWithVisibility(geometryData, visibilityData);
+
+            expect(result.featureCollection.features).toHaveLength(1);
+            expect(result.groups[0].exposureLayers).toHaveLength(2);
+        });
+    });
+
+    describe('fetchExposureLayers', () => {
+        it('fetches and merges geometry and visibility data', async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([
+                        {
+                            id: 'group-1',
+                            name: 'Floods',
+                            exposureLayers: [{ id: 'layer-1', name: 'Test Layer 1', geometry: mockGeometry }],
+                        },
+                    ]),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([
+                        {
+                            id: 'group-1',
+                            name: 'Floods',
+                            exposureLayers: [{ id: 'layer-1', name: 'Test Layer 1', isActive: true }],
+                        },
+                    ]),
+                });
+
+            const result = await fetchExposureLayers('scenario-1');
+
+            expect(result.featureCollection.type).toBe('FeatureCollection');
+            expect(result.featureCollection.features).toHaveLength(1);
+            expect(result.featureCollection.features[0].properties?.isActive).toBe(true);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes focusAreaId to visibility fetch', async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([]),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([]),
+                });
+
+            await fetchExposureLayers('scenario-1', 'focus-area-1');
+
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/exposurelayers/', expect.any(Object));
+            expect(fetchMock).toHaveBeenCalledWith('/ndtp-python/api/scenarios/scenario-1/exposure-layers/?focus_area_id=focus-area-1', expect.any(Object));
+        });
+
+        it('handles empty groups array', async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([]),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([]),
+                });
+
+            const result = await fetchExposureLayers('scenario-1');
 
             expect(result.featureCollection.type).toBe('FeatureCollection');
             expect(result.featureCollection.features).toHaveLength(0);
             expect(result.groups).toHaveLength(0);
         });
 
-        it('handles groups with empty exposure layers', async () => {
-            fetchMock.mockResolvedValue({
-                ok: true,
-                json: vi.fn().mockResolvedValue([
-                    {
-                        id: 'group-1',
-                        name: 'Floods',
-                        exposureLayers: [],
-                    },
-                    {
-                        id: 'group-2',
-                        name: 'Environmentally sensitive areas',
-                        exposureLayers: [],
-                    },
-                ]),
+        it('throws error when geometry fetch fails', async () => {
+            fetchMock.mockResolvedValueOnce({
+                ok: false,
+                statusText: 'Internal Server Error',
             });
 
-            const result = await fetchExposureLayers();
+            await expect(fetchExposureLayers('scenario-1')).rejects.toThrow('Failed to retrieve exposure layer geometry: Internal Server Error');
+        });
 
-            expect(result.featureCollection.features).toHaveLength(0);
-            expect(result.groups).toHaveLength(2);
-            expect(result.groups[0].exposureLayers).toHaveLength(0);
-            expect(result.groups[1].exposureLayers).toHaveLength(0);
+        it('throws error when visibility fetch fails', async () => {
+            fetchMock
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue([]),
+                })
+                .mockResolvedValueOnce({
+                    ok: false,
+                    statusText: 'Internal Server Error',
+                });
+
+            await expect(fetchExposureLayers('scenario-1')).rejects.toThrow('Failed to retrieve exposure layer visibility: Internal Server Error');
         });
     });
 });

--- a/frontend/src/api/exposure-layers.ts
+++ b/frontend/src/api/exposure-layers.ts
@@ -10,7 +10,8 @@ export type ExposureLayerGroup = {
 export type ExposureLayer = {
     id: string;
     name: string;
-    geometry: Geometry;
+    geometry?: Geometry;
+    isActive?: boolean;
 };
 
 export type ExposureLayersResponse = {
@@ -18,34 +19,70 @@ export type ExposureLayersResponse = {
     groups: ExposureLayerGroup[];
 };
 
-export const fetchExposureLayers = async (): Promise<ExposureLayersResponse> => {
+export type ToggleExposureLayerVisibilityRequest = {
+    exposureLayerId: string;
+    focusAreaId?: string | null;
+    isActive: boolean;
+};
+
+export const fetchExposureLayerGeometry = async (): Promise<ExposureLayerGroup[]> => {
     const response = await fetch(`${config.services.apiBaseUrl}/exposurelayers/`, {
         headers: { 'Content-Type': 'application/json' },
     });
 
     if (!response.ok) {
-        throw new Error(`Failed to retrieve exposure layers: ${response.statusText}`);
+        throw new Error(`Failed to retrieve exposure layer geometry: ${response.statusText}`);
     }
 
-    const data: ExposureLayerGroup[] = await response.json();
+    return response.json();
+};
 
-    const groups: ExposureLayerGroup[] = data.map((group) => ({
+export const fetchExposureLayerVisibility = async (scenarioId: string, focusAreaId?: string | null): Promise<ExposureLayerGroup[]> => {
+    let url = `${config.services.apiBaseUrl}/scenarios/${scenarioId}/exposure-layers/`;
+    if (focusAreaId !== undefined && focusAreaId !== null) {
+        url += `?focus_area_id=${focusAreaId}`;
+    }
+
+    const response = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to retrieve exposure layer visibility: ${response.statusText}`);
+    }
+
+    return response.json();
+};
+
+export const mergeGeometryWithVisibility = (geometryData: ExposureLayerGroup[], visibilityData: ExposureLayerGroup[]): ExposureLayersResponse => {
+    const visibilityMap = new Map<string, boolean>();
+    visibilityData.forEach((group) => {
+        group.exposureLayers.forEach((layer) => {
+            visibilityMap.set(layer.id, layer.isActive ?? false);
+        });
+    });
+
+    const mergedGroups: ExposureLayerGroup[] = geometryData.map((group) => ({
         id: group.id,
         name: group.name,
-        exposureLayers: group.exposureLayers,
+        exposureLayers: group.exposureLayers.map((layer) => ({
+            ...layer,
+            isActive: visibilityMap.get(layer.id) ?? false,
+        })),
     }));
 
-    const features: Feature[] = data.flatMap((group) =>
+    const features: Feature[] = mergedGroups.flatMap((group) =>
         group.exposureLayers
             .filter((layer) => layer.geometry)
             .map((layer) => ({
                 type: 'Feature' as const,
                 id: layer.id,
-                geometry: layer.geometry,
+                geometry: layer.geometry!,
                 properties: {
                     name: layer.name,
                     groupId: group.id,
                     groupName: group.name,
+                    isActive: layer.isActive ?? false,
                 },
             })),
     );
@@ -55,6 +92,28 @@ export const fetchExposureLayers = async (): Promise<ExposureLayersResponse> => 
             type: 'FeatureCollection',
             features,
         },
-        groups,
+        groups: mergedGroups,
     };
+};
+
+export const fetchExposureLayers = async (scenarioId: string, focusAreaId?: string | null): Promise<ExposureLayersResponse> => {
+    const [geometryData, visibilityData] = await Promise.all([fetchExposureLayerGeometry(), fetchExposureLayerVisibility(scenarioId, focusAreaId)]);
+
+    return mergeGeometryWithVisibility(geometryData, visibilityData);
+};
+
+export const toggleExposureLayerVisibility = async (scenarioId: string, data: ToggleExposureLayerVisibilityRequest): Promise<void> => {
+    const response = await fetch(`${config.services.apiBaseUrl}/scenarios/${scenarioId}/visible-exposure-layers/`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            exposureLayerId: data.exposureLayerId,
+            focusAreaId: data.focusAreaId ?? null,
+            isActive: data.isActive,
+        }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to toggle exposure layer visibility: ${response.statusText}`);
+    }
 };

--- a/frontend/src/components/map-v2/ExposureLayers.test.tsx
+++ b/frontend/src/components/map-v2/ExposureLayers.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@mui/material/styles';
-import type { FeatureCollection } from 'geojson';
+import type { FeatureCollection, Geometry } from 'geojson';
 
 import ExposureLayers from './ExposureLayers';
 import theme from '@/theme';
+import { fetchExposureLayers, type ExposureLayersResponse } from '@/api/exposure-layers';
 
-const mockUseMap = vi.fn();
 vi.mock('react-map-gl/maplibre', () => ({
-    useMap: () => mockUseMap(),
+    useMap: () => ({}),
     Source: ({ children, data }: { children: React.ReactNode; data: FeatureCollection }) => (
         <div data-testid="source" data-features-count={data.features.length}>
             {children}
@@ -19,56 +19,67 @@ vi.mock('react-map-gl/maplibre', () => ({
     Layer: ({ id }: { id: string }) => <div data-testid={`layer-${id}`} />,
 }));
 
+vi.mock('@/api/exposure-layers', () => ({
+    fetchExposureLayers: vi.fn(),
+}));
+
+const mockedFetchExposureLayers = vi.mocked(fetchExposureLayers);
+
 describe('ExposureLayers', () => {
-    const mockPolygonFeature: FeatureCollection = {
-        type: 'FeatureCollection',
-        features: [
-            {
-                type: 'Feature',
-                id: '35a910f3-f611-4096-ac0b-0928c5612e32',
-                geometry: {
-                    type: 'Polygon',
-                    coordinates: [
-                        [
-                            [-1.4, 50.67],
-                            [-1.4, 50.68],
-                            [-1.39, 50.68],
-                            [-1.39, 50.67],
-                            [-1.4, 50.67],
-                        ],
-                    ],
-                },
-                properties: {
-                    name: 'Caul Bourne',
-                },
-            },
-            {
-                type: 'Feature',
-                id: 'e34e3c22-a28f-45e5-99b5-a24b55ba875f',
-                geometry: {
-                    type: 'Polygon',
-                    coordinates: [
-                        [
-                            [-1.3, 50.66],
-                            [-1.3, 50.67],
-                            [-1.29, 50.67],
-                            [-1.29, 50.66],
-                            [-1.3, 50.66],
-                        ],
-                    ],
-                },
-                properties: {
-                    name: 'River Medina',
-                },
-            },
+    const mockGeometry1: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.4, 50.67],
+                [-1.4, 50.68],
+                [-1.39, 50.68],
+                [-1.39, 50.67],
+                [-1.4, 50.67],
+            ],
         ],
     };
 
-    const defaultProps = {
-        exposureLayers: mockPolygonFeature,
-        selectedExposureLayerIds: {} as Record<string, boolean>,
-        mapReady: true,
+    const mockGeometry2: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.3, 50.66],
+                [-1.3, 50.67],
+                [-1.29, 50.67],
+                [-1.29, 50.66],
+                [-1.3, 50.66],
+            ],
+        ],
     };
+
+    const createMockResponse = (layers: Array<{ id: string; name: string; isActive: boolean; geometry: Geometry }>): ExposureLayersResponse => ({
+        featureCollection: {
+            type: 'FeatureCollection',
+            features: layers.map((layer) => ({
+                type: 'Feature',
+                id: layer.id,
+                geometry: layer.geometry,
+                properties: {
+                    name: layer.name,
+                    groupId: 'group-1',
+                    groupName: 'Floods',
+                    isActive: layer.isActive,
+                },
+            })),
+        },
+        groups: [
+            {
+                id: 'group-1',
+                name: 'Floods',
+                exposureLayers: layers.map((layer) => ({
+                    id: layer.id,
+                    name: layer.name,
+                    geometry: layer.geometry,
+                    isActive: layer.isActive,
+                })),
+            },
+        ],
+    });
 
     let queryClient: QueryClient;
 
@@ -81,7 +92,6 @@ describe('ExposureLayers', () => {
             },
         });
         vi.clearAllMocks();
-        mockUseMap.mockReturnValue({});
     });
 
     const renderWithProviders = (component: React.ReactElement) => {
@@ -94,254 +104,219 @@ describe('ExposureLayers', () => {
 
     describe('Rendering', () => {
         it('returns null when map is not ready', () => {
-            const { container } = renderWithProviders(<ExposureLayers {...defaultProps} mapReady={false} />);
+            const { container } = renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={false} />);
             expect(container.firstChild).toBeNull();
         });
 
-        it('returns null when there are no selected layers', () => {
-            const { container } = renderWithProviders(<ExposureLayers {...defaultProps} />);
+        it('returns null when scenarioId is not provided', () => {
+            const { container } = renderWithProviders(<ExposureLayers mapReady={true} />);
             expect(container.firstChild).toBeNull();
         });
 
-        it('returns null when filtered features is empty', () => {
-            const { container } = renderWithProviders(<ExposureLayers {...defaultProps} selectedExposureLayerIds={{ 'non-existent-id': true }} />);
-            expect(container.firstChild).toBeNull();
-        });
+        it('renders Source and Layers when data is loaded with active layers', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]));
 
-        it('renders Source and Layers when map is ready and layers are selected', () => {
-            renderWithProviders(<ExposureLayers {...defaultProps} selectedExposureLayerIds={{ '35a910f3-f611-4096-ac0b-0928c5612e32': true }} />);
-            expect(screen.getByTestId('source')).toBeInTheDocument();
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('source')).toBeInTheDocument();
+            });
             expect(screen.getByTestId('layer-map-v2-exposure-layer')).toBeInTheDocument();
             expect(screen.getByTestId('layer-map-v2-exposure-layer-outline')).toBeInTheDocument();
+        });
+
+        it('returns null when no layers are active', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: false, geometry: mockGeometry1 }]));
+
+            const { container } = renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalled();
+            });
+
+            await waitFor(() => {
+                expect(container.querySelector('[data-testid="source"]')).toBeNull();
+            });
         });
     });
 
     describe('Layer Filtering', () => {
-        it('filters layers by selected exposure layer IDs', () => {
-            renderWithProviders(
-                <ExposureLayers
-                    {...defaultProps}
-                    selectedExposureLayerIds={{ '35a910f3-f611-4096-ac0b-0928c5612e32': true, 'e34e3c22-a28f-45e5-99b5-a24b55ba875f': false }}
-                />,
+        it('only renders active layers', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(
+                createMockResponse([
+                    { id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 },
+                    { id: 'layer-2', name: 'River Medina', isActive: false, geometry: mockGeometry2 },
+                ]),
             );
-            const source = screen.getByTestId('source');
-            expect(source).toHaveAttribute('data-features-count', '1');
+
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                const source = screen.getByTestId('source');
+                expect(source).toHaveAttribute('data-features-count', '1');
+            });
         });
 
-        it('renders all selected layers', () => {
-            renderWithProviders(
-                <ExposureLayers
-                    {...defaultProps}
-                    selectedExposureLayerIds={{ '35a910f3-f611-4096-ac0b-0928c5612e32': true, 'e34e3c22-a28f-45e5-99b5-a24b55ba875f': true }}
-                />,
+        it('renders all active layers', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(
+                createMockResponse([
+                    { id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 },
+                    { id: 'layer-2', name: 'River Medina', isActive: true, geometry: mockGeometry2 },
+                ]),
             );
-            const source = screen.getByTestId('source');
-            expect(source).toHaveAttribute('data-features-count', '2');
-        });
 
-        it('handles multiple layers of the same type', () => {
-            const multipleLayers: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [
-                    ...mockPolygonFeature.features,
-                    {
-                        type: 'Feature',
-                        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
-                        geometry: {
-                            type: 'Polygon',
-                            coordinates: [
-                                [
-                                    [-1.2, 50.65],
-                                    [-1.2, 50.66],
-                                    [-1.19, 50.66],
-                                    [-1.19, 50.65],
-                                    [-1.2, 50.65],
-                                ],
-                            ],
-                        },
-                        properties: {
-                            name: 'Layer 3',
-                        },
-                    },
-                ],
-            };
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
 
-            renderWithProviders(
-                <ExposureLayers
-                    exposureLayers={multipleLayers}
-                    selectedExposureLayerIds={{
-                        '35a910f3-f611-4096-ac0b-0928c5612e32': true,
-                        'e34e3c22-a28f-45e5-99b5-a24b55ba875f': true,
-                        'a1b2c3d4-e5f6-7890-abcd-ef1234567890': true,
-                    }}
-                    mapReady={true}
-                />,
-            );
-            const source = screen.getByTestId('source');
-            expect(source).toHaveAttribute('data-features-count', '3');
+            await waitFor(() => {
+                const source = screen.getByTestId('source');
+                expect(source).toHaveAttribute('data-features-count', '2');
+            });
         });
     });
 
-    describe('Feature ID Handling', () => {
-        it('handles features with id property', () => {
-            renderWithProviders(<ExposureLayers {...defaultProps} selectedExposureLayerIds={{ '35a910f3-f611-4096-ac0b-0928c5612e32': true }} />);
-            expect(screen.getByTestId('source')).toBeInTheDocument();
+    describe('Focus Area Selection', () => {
+        it('fetches data for selected focus area', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]));
+
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" selectedFocusAreaId="focus-area-1" mapReady={true} />);
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', 'focus-area-1');
+            });
         });
 
-        it('handles features with id in properties', () => {
-            const featureWithPropertyId: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [
-                    {
-                        type: 'Feature',
-                        properties: {
-                            id: '11111111-2222-3333-4444-555555555555',
-                            name: 'Test Layer',
-                        },
-                        geometry: {
-                            type: 'Polygon',
-                            coordinates: [
-                                [
-                                    [-1.4, 50.67],
-                                    [-1.4, 50.68],
-                                    [-1.39, 50.68],
-                                    [-1.39, 50.67],
-                                    [-1.4, 50.67],
-                                ],
-                            ],
-                        },
-                    },
-                ],
-            };
+        it('fetches map-wide data when no focus area is selected', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]));
 
-            renderWithProviders(
-                <ExposureLayers
-                    exposureLayers={featureWithPropertyId}
-                    selectedExposureLayerIds={{ '11111111-2222-3333-4444-555555555555': true }}
-                    mapReady={true}
-                />,
-            );
-            expect(screen.getByTestId('source')).toBeInTheDocument();
-        });
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" selectedFocusAreaId={null} mapReady={true} />);
 
-        it('filters out features without IDs', () => {
-            const featureWithoutId: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [
-                    {
-                        type: 'Feature',
-                        properties: {
-                            name: 'Test Layer',
-                        },
-                        geometry: {
-                            type: 'Polygon',
-                            coordinates: [
-                                [
-                                    [-1.4, 50.67],
-                                    [-1.4, 50.68],
-                                    [-1.39, 50.68],
-                                    [-1.39, 50.67],
-                                    [-1.4, 50.67],
-                                ],
-                            ],
-                        },
-                    },
-                ],
-            };
-
-            const { container } = renderWithProviders(
-                <ExposureLayers exposureLayers={featureWithoutId} selectedExposureLayerIds={{ 'some-id': true }} mapReady={true} />,
-            );
-
-            expect(container.firstChild).toBeNull();
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', null);
+            });
         });
     });
 
-    describe('MultiPolygon Support', () => {
-        it('handles MultiPolygon geometries', () => {
-            const multiPolygonFeature: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [
-                    {
-                        type: 'Feature',
-                        id: 'f9e8d7c6-b5a4-3210-9876-543210fedcba',
-                        geometry: {
-                            type: 'MultiPolygon',
-                            coordinates: [
-                                [
-                                    [
-                                        [-1.4, 50.67],
-                                        [-1.4, 50.68],
-                                        [-1.39, 50.68],
-                                        [-1.39, 50.67],
-                                        [-1.4, 50.67],
-                                    ],
-                                ],
-                            ],
-                        },
-                        properties: {
-                            name: 'MultiPolygon Layer',
-                        },
-                    },
-                ],
-            };
+    describe('Focus Area Panel Aggregation', () => {
+        it('fetches data for all active focus areas when in focus area panel', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]));
 
             renderWithProviders(
                 <ExposureLayers
-                    exposureLayers={multiPolygonFeature}
-                    selectedExposureLayerIds={{ 'f9e8d7c6-b5a4-3210-9876-543210fedcba': true }}
+                    scenarioId="scenario-1"
                     mapReady={true}
+                    isInFocusAreaPanel={true}
+                    mapWideVisible={true}
+                    activeFocusAreaIds={['fa-1', 'fa-2']}
                 />,
             );
-            expect(screen.getByTestId('source')).toBeInTheDocument();
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', null);
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', 'fa-1');
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', 'fa-2');
+            });
+        });
+
+        it('does not fetch map-wide when mapWideVisible is false', async () => {
+            mockedFetchExposureLayers.mockResolvedValue(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]));
+
+            renderWithProviders(
+                <ExposureLayers scenarioId="scenario-1" mapReady={true} isInFocusAreaPanel={true} mapWideVisible={false} activeFocusAreaIds={['fa-1']} />,
+            );
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalledWith('scenario-1', 'fa-1');
+                expect(mockedFetchExposureLayers).not.toHaveBeenCalledWith('scenario-1', null);
+            });
+        });
+
+        it('aggregates active layers from multiple focus areas', async () => {
+            mockedFetchExposureLayers
+                .mockResolvedValueOnce(createMockResponse([{ id: 'layer-1', name: 'Caul Bourne', isActive: true, geometry: mockGeometry1 }]))
+                .mockResolvedValueOnce(createMockResponse([{ id: 'layer-2', name: 'River Medina', isActive: true, geometry: mockGeometry2 }]));
+
+            renderWithProviders(
+                <ExposureLayers
+                    scenarioId="scenario-1"
+                    mapReady={true}
+                    isInFocusAreaPanel={true}
+                    mapWideVisible={false}
+                    activeFocusAreaIds={['fa-1', 'fa-2']}
+                />,
+            );
+
+            await waitFor(() => {
+                const source = screen.getByTestId('source');
+                expect(source).toHaveAttribute('data-features-count', '2');
+            });
         });
     });
 
     describe('Edge Cases', () => {
-        it('handles empty exposure layers', () => {
-            const emptyLayers: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [],
-            };
+        it('handles empty response', async () => {
+            mockedFetchExposureLayers.mockResolvedValue({
+                featureCollection: { type: 'FeatureCollection', features: [] },
+                groups: [],
+            });
 
-            const { container } = renderWithProviders(
-                <ExposureLayers exposureLayers={emptyLayers} selectedExposureLayerIds={{ 'any-id': true }} mapReady={true} />,
-            );
-            expect(container.firstChild).toBeNull();
+            const { container } = renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalled();
+            });
+
+            await waitFor(() => {
+                expect(container.querySelector('[data-testid="source"]')).toBeNull();
+            });
         });
 
-        it('handles features with empty properties', () => {
-            const featureWithEmptyProperties: FeatureCollection = {
-                type: 'FeatureCollection',
-                features: [
-                    {
-                        type: 'Feature',
-                        id: '22222222-3333-4444-5555-666666666666',
-                        geometry: {
-                            type: 'Polygon',
-                            coordinates: [
-                                [
-                                    [-1.4, 50.67],
-                                    [-1.4, 50.68],
-                                    [-1.39, 50.68],
-                                    [-1.39, 50.67],
-                                    [-1.4, 50.67],
-                                ],
-                            ],
+        it('handles features without IDs', async () => {
+            mockedFetchExposureLayers.mockResolvedValue({
+                featureCollection: {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            geometry: mockGeometry1,
+                            properties: { name: 'Test Layer', isActive: true },
                         },
-                        properties: {},
-                    },
-                ],
-            };
+                    ],
+                },
+                groups: [],
+            });
 
-            renderWithProviders(
-                <ExposureLayers
-                    exposureLayers={featureWithEmptyProperties}
-                    selectedExposureLayerIds={{ '22222222-3333-4444-5555-666666666666': true }}
-                    mapReady={true}
-                />,
-            );
-            expect(screen.getByTestId('source')).toBeInTheDocument();
+            const { container } = renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                expect(mockedFetchExposureLayers).toHaveBeenCalled();
+            });
+
+            await waitFor(() => {
+                expect(container.querySelector('[data-testid="source"]')).toBeNull();
+            });
+        });
+
+        it('uses properties.id when feature.id is not set', async () => {
+            mockedFetchExposureLayers.mockResolvedValue({
+                featureCollection: {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            geometry: mockGeometry1,
+                            properties: { id: 'prop-id-1', name: 'Test Layer', isActive: true },
+                        },
+                    ],
+                },
+                groups: [],
+            });
+
+            renderWithProviders(<ExposureLayers scenarioId="scenario-1" mapReady={true} />);
+
+            await waitFor(() => {
+                const source = screen.getByTestId('source');
+                expect(source).toHaveAttribute('data-features-count', '1');
+            });
         });
     });
 });

--- a/frontend/src/components/map-v2/ExposureLayers.tsx
+++ b/frontend/src/components/map-v2/ExposureLayers.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import type { FeatureCollection } from 'geojson';
+import { useQueries } from '@tanstack/react-query';
+import type { FeatureCollection, Feature } from 'geojson';
+import { fetchExposureLayers } from '@/api/exposure-layers';
 
 const SOURCE_ID = 'map-v2-exposure-source';
 const LAYER_ID = 'map-v2-exposure-layer';
@@ -10,33 +12,91 @@ const DEFAULT_STROKE_COLOR = '#2E5C8A';
 const DEFAULT_STROKE_WIDTH = 2;
 
 export type ExposureLayersProps = {
-    exposureLayers: FeatureCollection;
-    selectedExposureLayerIds: Record<string, boolean>;
+    scenarioId?: string;
+    selectedFocusAreaId?: string | null;
     mapReady?: boolean;
+    isInFocusAreaPanel?: boolean;
+    mapWideVisible?: boolean;
+    activeFocusAreaIds?: string[];
 };
 
-const ExposureLayers = ({ exposureLayers, selectedExposureLayerIds, mapReady }: ExposureLayersProps) => {
-    const filteredFeatures = useMemo(() => {
-        const enabledIdsSet = new Set(
-            Object.entries(selectedExposureLayerIds)
-                .filter(([, enabled]) => enabled)
-                .map(([id]) => id),
-        );
-
-        if (enabledIdsSet.size === 0) {
+const ExposureLayers = ({
+    scenarioId,
+    selectedFocusAreaId,
+    mapReady,
+    isInFocusAreaPanel = false,
+    mapWideVisible = true,
+    activeFocusAreaIds = [],
+}: ExposureLayersProps) => {
+    const queryConfigs = useMemo(() => {
+        if (!scenarioId) {
             return [];
         }
 
-        const filtered = exposureLayers.features.filter((feature) => {
-            const featureId = feature.id || feature.properties?.id;
-            const idString = featureId !== null && featureId !== undefined ? String(featureId) : null;
-            if (idString) {
-                return enabledIdsSet.has(idString);
+        if (isInFocusAreaPanel) {
+            const configs = [];
+            if (mapWideVisible) {
+                configs.push({
+                    queryKey: ['exposureLayers', scenarioId, null],
+                    queryFn: () => fetchExposureLayers(scenarioId, null),
+                    staleTime: 0,
+                });
             }
-            return false;
+            activeFocusAreaIds.forEach((faId) => {
+                configs.push({
+                    queryKey: ['exposureLayers', scenarioId, faId],
+                    queryFn: () => fetchExposureLayers(scenarioId, faId),
+                    staleTime: 0,
+                });
+            });
+            return configs;
+        }
+
+        return [
+            {
+                queryKey: ['exposureLayers', scenarioId, selectedFocusAreaId],
+                queryFn: () => fetchExposureLayers(scenarioId, selectedFocusAreaId),
+                staleTime: 0,
+            },
+        ];
+    }, [scenarioId, isInFocusAreaPanel, mapWideVisible, activeFocusAreaIds, selectedFocusAreaId]);
+
+    const exposureQueries = useQueries({
+        queries: queryConfigs.length > 0 ? queryConfigs : [],
+    });
+
+    const isLoading = exposureQueries.some((q) => q.isLoading);
+
+    const filteredFeatures = useMemo(() => {
+        const activeFeatureIds = new Set<string>();
+        const featuresById = new Map<string, Feature>();
+
+        exposureQueries.forEach((query) => {
+            if (!query.data?.featureCollection?.features) {
+                return;
+            }
+
+            query.data.featureCollection.features.forEach((feature: Feature) => {
+                const featureId = feature.id?.toString() || feature.properties?.id;
+                if (!featureId) {
+                    return;
+                }
+
+                if (!featuresById.has(featureId)) {
+                    featuresById.set(featureId, feature);
+                }
+
+                if (feature.properties?.isActive === true) {
+                    activeFeatureIds.add(featureId);
+                }
+            });
         });
-        return filtered;
-    }, [exposureLayers, selectedExposureLayerIds]);
+
+        return Array.from(featuresById.values()).filter((feature) => {
+            const featureId = feature.id?.toString() || feature.properties?.id;
+            return featureId && activeFeatureIds.has(featureId);
+        });
+    }, [exposureQueries]);
 
     const featureCollection: FeatureCollection = useMemo(() => {
         return {
@@ -45,12 +105,12 @@ const ExposureLayers = ({ exposureLayers, selectedExposureLayerIds, mapReady }: 
         };
     }, [filteredFeatures]);
 
-    if (!mapReady || filteredFeatures.length === 0) {
+    if (!mapReady || !scenarioId || isLoading || filteredFeatures.length === 0) {
         return null;
     }
 
     return (
-        <Source id={SOURCE_ID} type="geojson" data={featureCollection}>
+        <Source id={SOURCE_ID} type="geojson" data={featureCollection} generateId>
             <Layer
                 id={LAYER_ID}
                 type="fill"

--- a/frontend/src/components/map-v2/MapPanels.tsx
+++ b/frontend/src/components/map-v2/MapPanels.tsx
@@ -54,8 +54,7 @@ type RoadRoutePosition = {
 type MapPanelsProps = {
     activeView?: string | null;
     onViewChange?: (viewId: string | null) => void;
-    selectedExposureLayerIds?: Record<string, boolean>;
-    onExposureLayerToggle?: (layerId: string, enabled: boolean) => void;
+    selectedFocusAreaId?: string | null;
     selectedUtilityIds?: Record<string, boolean>;
     onUtilityToggle?: (utilityId: string, enabled: boolean) => void;
     selectedElement?: Asset | null;
@@ -79,8 +78,7 @@ type MapPanelsProps = {
 const MapPanels = ({
     activeView,
     onViewChange,
-    selectedExposureLayerIds,
-    onExposureLayerToggle,
+    selectedFocusAreaId,
     selectedUtilityIds,
     onUtilityToggle,
     selectedElement,
@@ -102,16 +100,10 @@ const MapPanels = ({
 }: Readonly<MapPanelsProps>) => {
     const handleItemClick = (itemId: string) => {
         const newActiveView = activeView === itemId ? null : itemId;
-        if (activeView === 'assets' && newActiveView !== 'assets') {
-            onFocusAreaSelect?.(null);
-        }
         onViewChange?.(newActiveView);
     };
 
     const handleClosePanel = () => {
-        if (activeView === 'assets') {
-            onFocusAreaSelect?.(null);
-        }
         onViewChange?.(null);
     };
 
@@ -124,13 +116,21 @@ const MapPanels = ({
             case 'scenario':
                 return <ScenarioView onItemClick={handleItemClick} onClose={handleClosePanel} />;
             case 'assets':
-                return <AssetsView onClose={handleClosePanel} scenarioId={scenarioId} onFocusAreaSelect={onFocusAreaSelect} />;
+                return (
+                    <AssetsView
+                        onClose={handleClosePanel}
+                        scenarioId={scenarioId}
+                        selectedFocusAreaId={selectedFocusAreaId}
+                        onFocusAreaSelect={onFocusAreaSelect}
+                    />
+                );
             case 'exposure':
                 return (
                     <ExposureView
                         onClose={handleClosePanel}
-                        selectedExposureLayerIds={selectedExposureLayerIds}
-                        onExposureLayerToggle={onExposureLayerToggle}
+                        scenarioId={scenarioId}
+                        selectedFocusAreaId={selectedFocusAreaId}
+                        onFocusAreaSelect={onFocusAreaSelect}
                     />
                 );
             case 'utilities':

--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -3,7 +3,7 @@ import { Box } from '@mui/material';
 import type { MapRef, ViewStateChangeEvent } from 'react-map-gl/maplibre';
 import type { MapMouseEvent } from 'maplibre-gl';
 import Map, { Marker } from 'react-map-gl/maplibre';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './mapbox-draw-maplibre.css';
@@ -24,9 +24,24 @@ import { useAssetTypeIcons } from '@/hooks/useAssetTypeIcons';
 import { useActiveScenario } from '@/hooks/useActiveScenario';
 import { useScenarioAssets } from '@/hooks/useScenarioAssets';
 import { fetchAssetCategories } from '@/api/asset-categories';
-import { fetchExposureLayers } from '@/api/exposure-layers';
+import { fetchScenarioAssetTypes } from '@/api/scenario-asset-types';
 import { useRoadRouteLazyQuery, type RoadRouteInputParams } from '@/api/utilities';
 import type { Asset } from '@/api/assets-by-type';
+import type { ScenarioAssetCategory } from '@/api/scenario-asset-types';
+
+const extractVisibleAssetTypeIds = (categories: ScenarioAssetCategory[]): string[] => {
+    const ids: string[] = [];
+    for (const category of categories) {
+        for (const subCategory of category.subCategories ?? []) {
+            for (const assetType of subCategory.assetTypes ?? []) {
+                if (assetType.isActive) {
+                    ids.push(assetType.id);
+                }
+            }
+        }
+    }
+    return ids;
+};
 
 const MapView = () => {
     const mapRef = useRef<MapRef>(null);
@@ -36,7 +51,6 @@ const MapView = () => {
     const [mapStylePanelOpen, setMapStylePanelOpen] = useState(false);
     const [assetInfoPanelOpen, setAssetInfoPanelOpen] = useState(false);
     const [activePanelView, setActivePanelView] = useState<string | null>('focus-area');
-    const [selectedExposureLayerIds, setSelectedExposureLayerIds] = useState<Record<string, boolean>>({});
     const [selectedUtilityIds, setSelectedUtilityIds] = useState<Record<string, boolean>>({});
     const [selectedElement, setSelectedElement] = useState<Asset | null>(null);
     const [previousPanelView, setPreviousPanelView] = useState<string | null>('focus-area');
@@ -102,12 +116,6 @@ const MapView = () => {
         staleTime: 5 * 60 * 1000,
     });
 
-    const { data: exposureLayers } = useQuery({
-        queryKey: ['exposureLayers'],
-        queryFn: fetchExposureLayers,
-        staleTime: 5 * 60 * 1000,
-    });
-
     const [getRoadRoute, { data: roadRouteQueryData, loading: roadRouteLoading, error: roadRouteError }] = useRoadRouteLazyQuery();
 
     const isRoadRouteEnabled = selectedUtilityIds['road-route'] ?? false;
@@ -126,11 +134,74 @@ const MapView = () => {
         }
     }, [roadRouteStart, roadRouteEnd, roadRouteVehicle, isRoadRouteEnabled, getRoadRoute]);
 
-    const { assets } = useScenarioAssets({
+    const { assets: allAssets } = useScenarioAssets({
         scenarioId,
         excludeMapWide: !mapWideVisible,
         iconMap,
     });
+
+    const isInFocusAreaPanel = activePanelView === 'focus-area';
+
+    const activeFocusAreaIds = useMemo(() => {
+        if (!focusAreas) {
+            return [];
+        }
+        return focusAreas.filter((fa) => fa.isActive).map((fa) => fa.id);
+    }, [focusAreas]);
+
+    const assetTypeQueryConfigs = useMemo(() => {
+        if (!scenarioId) {
+            return [];
+        }
+
+        if (isInFocusAreaPanel) {
+            const configs = [];
+            if (mapWideVisible) {
+                configs.push({
+                    queryKey: ['scenarioAssetTypes', scenarioId, null],
+                    queryFn: () => fetchScenarioAssetTypes(scenarioId, null),
+                    staleTime: 0,
+                });
+            }
+            activeFocusAreaIds.forEach((faId) => {
+                configs.push({
+                    queryKey: ['scenarioAssetTypes', scenarioId, faId],
+                    queryFn: () => fetchScenarioAssetTypes(scenarioId, faId),
+                    staleTime: 0,
+                });
+            });
+            return configs;
+        }
+
+        return [
+            {
+                queryKey: ['scenarioAssetTypes', scenarioId, selectedFocusAreaId],
+                queryFn: () => fetchScenarioAssetTypes(scenarioId, selectedFocusAreaId),
+                staleTime: 0,
+            },
+        ];
+    }, [scenarioId, isInFocusAreaPanel, mapWideVisible, activeFocusAreaIds, selectedFocusAreaId]);
+
+    const assetTypeQueries = useQueries({
+        queries: assetTypeQueryConfigs.length > 0 ? assetTypeQueryConfigs : [],
+    });
+
+    const visibleAssetTypeIds = useMemo(() => {
+        const ids = new Set<string>();
+        for (const query of assetTypeQueries) {
+            if (query.data && Array.isArray(query.data)) {
+                extractVisibleAssetTypeIds(query.data).forEach((id) => ids.add(id));
+            }
+        }
+        return ids;
+    }, [assetTypeQueries]);
+
+    const assets = useMemo(() => {
+        if (visibleAssetTypeIds.size === 0) {
+            return [];
+        }
+        return allAssets.filter((asset) => visibleAssetTypeIds.has(asset.type));
+    }, [allAssets, visibleAssetTypeIds]);
 
     usePreloadAssetIcons(assets);
 
@@ -325,13 +396,7 @@ const MapView = () => {
             <MapPanels
                 activeView={activePanelView}
                 onViewChange={handleViewChange}
-                selectedExposureLayerIds={selectedExposureLayerIds}
-                onExposureLayerToggle={(layerId, enabled) => {
-                    setSelectedExposureLayerIds((prev) => ({
-                        ...prev,
-                        [layerId]: enabled,
-                    }));
-                }}
+                selectedFocusAreaId={selectedFocusAreaId}
                 selectedUtilityIds={selectedUtilityIds}
                 onUtilityToggle={(utilityId, enabled) => {
                     setSelectedUtilityIds((prev) => ({
@@ -396,7 +461,9 @@ const MapView = () => {
                 >
                     {mapReady && (
                         <>
-                            <FocusAreaMask geometry={focusAreas?.find((fa) => fa.id === selectedFocusAreaId)?.geometry ?? null} />
+                            {!isInFocusAreaPanel && selectedFocusAreaId && (
+                                <FocusAreaMask geometry={focusAreas?.find((fa) => fa.id === selectedFocusAreaId)?.geometry ?? null} />
+                            )}
                             <AssetLayers
                                 assets={assets}
                                 selectedElements={selectedElement ? [selectedElement] : []}
@@ -404,13 +471,14 @@ const MapView = () => {
                                 mapReady={mapReady}
                                 assetCategories={assetCategories}
                             />
-                            {exposureLayers && (
-                                <ExposureLayers
-                                    exposureLayers={exposureLayers.featureCollection}
-                                    selectedExposureLayerIds={selectedExposureLayerIds}
-                                    mapReady={mapReady}
-                                />
-                            )}
+                            <ExposureLayers
+                                scenarioId={scenarioId}
+                                selectedFocusAreaId={selectedFocusAreaId}
+                                mapReady={mapReady}
+                                isInFocusAreaPanel={isInFocusAreaPanel}
+                                mapWideVisible={mapWideVisible}
+                                activeFocusAreaIds={activeFocusAreaIds}
+                            />
                             <UtilitiesLayers utilities={mergedUtilities} selectedUtilityIds={selectedUtilityIds} mapReady={mapReady} />
                             {roadRouteStart && (
                                 <Marker longitude={roadRouteStart.lng} latitude={roadRouteStart.lat} anchor="bottom">

--- a/frontend/src/components/map-v2/panels/AssetsView.test.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.test.tsx
@@ -247,9 +247,10 @@ describe('AssetsView', () => {
             expect(screen.getByRole('option', { name: 'Area 1' })).toBeInTheDocument();
         });
 
-        it('refetches asset types when focus area changes', async () => {
+        it('calls onFocusAreaSelect when focus area changes', async () => {
+            const onFocusAreaSelect = vi.fn();
             setupMocks();
-            renderWithProviders(<AssetsView {...defaultProps} />);
+            renderWithProviders(<AssetsView {...defaultProps} onFocusAreaSelect={onFocusAreaSelect} />);
 
             await waitFor(() => {
                 expect(mockedFetchFocusAreas).toHaveBeenCalled();
@@ -271,6 +272,15 @@ describe('AssetsView', () => {
 
             const area1Option = screen.getByRole('option', { name: 'Area 1' });
             fireEvent.click(area1Option);
+
+            await waitFor(() => {
+                expect(onFocusAreaSelect).toHaveBeenCalledWith('focus-area-1');
+            });
+        });
+
+        it('fetches asset types for the selected focus area', async () => {
+            setupMocks();
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId="focus-area-1" />);
 
             await waitFor(() => {
                 expect(mockedFetchScenarioAssetTypes).toHaveBeenCalledWith('test-scenario-id', 'focus-area-1');

--- a/frontend/src/components/map-v2/panels/AssetsView.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.tsx
@@ -23,6 +23,7 @@ import {
 type AssetsViewProps = {
     readonly onClose: () => void;
     readonly scenarioId?: string;
+    readonly selectedFocusAreaId?: string | null;
     readonly onFocusAreaSelect?: (focusAreaId: string | null) => void;
 };
 
@@ -88,14 +89,14 @@ function AssetTypeList({ assetTypes, onToggle, disabled, dataSourceMap }: AssetT
     );
 }
 
-const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps) => {
+const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelect }: AssetsViewProps) => {
     const [searchQuery, setSearchQuery] = useState('');
     const deferredSearchQuery = useDeferredValue(searchQuery);
     const [expandedSubCategories, setExpandedSubCategories] = useState<Set<string>>(new Set());
-    const [selectedFocusAreaId, setSelectedFocusAreaId] = useState<string | null>(null);
     const [mutationError, setMutationError] = useState<string | null>(null);
     const queryClient = useQueryClient();
     const { dataSourceMap } = useDataSources();
+    const currentFocusAreaId = selectedFocusAreaId ?? null;
 
     const { data: focusAreas, isLoading: isLoadingFocusAreas } = useQuery({
         queryKey: ['focusAreas', scenarioId],
@@ -109,8 +110,8 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
         isLoading: isLoadingCategories,
         isError: isErrorCategories,
     } = useQuery({
-        queryKey: ['scenarioAssetTypes', scenarioId, selectedFocusAreaId],
-        queryFn: () => fetchScenarioAssetTypes(scenarioId!, selectedFocusAreaId),
+        queryKey: ['scenarioAssetTypes', scenarioId, currentFocusAreaId],
+        queryFn: () => fetchScenarioAssetTypes(scenarioId!, currentFocusAreaId),
         enabled: !!scenarioId,
         staleTime: 5 * 60 * 1000,
     });
@@ -119,7 +120,7 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
         mutationFn: (data: { assetTypeId: string; isActive: boolean }) =>
             toggleAssetTypeVisibility(scenarioId!, {
                 assetTypeId: data.assetTypeId,
-                focusAreaId: selectedFocusAreaId,
+                focusAreaId: currentFocusAreaId,
                 isActive: data.isActive,
             }),
         onSuccess: () => {
@@ -132,7 +133,7 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
     });
 
     const clearAllMutation = useMutation({
-        mutationFn: () => clearAllAssetTypeVisibility(scenarioId!, selectedFocusAreaId),
+        mutationFn: () => clearAllAssetTypeVisibility(scenarioId!, currentFocusAreaId),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['scenarioAssetTypes', scenarioId] });
             queryClient.invalidateQueries({ queryKey: ['scenarioAssets', scenarioId] });
@@ -149,10 +150,10 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
             return;
         }
 
-        if (lastFocusAreaIdRef.current === selectedFocusAreaId) {
+        if (lastFocusAreaIdRef.current === currentFocusAreaId) {
             return;
         }
-        lastFocusAreaIdRef.current = selectedFocusAreaId;
+        lastFocusAreaIdRef.current = currentFocusAreaId;
 
         const visibleSubCategoryIds = new Set<string>();
         for (const category of assetCategories) {
@@ -164,13 +165,12 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
             }
         }
         setExpandedSubCategories(visibleSubCategoryIds);
-    }, [assetCategories, selectedFocusAreaId]);
+    }, [assetCategories, currentFocusAreaId]);
 
     const handleFocusAreaChange = useCallback(
         (event: SelectChangeEvent<string>) => {
             const value = event.target.value;
             const newFocusAreaId = value === MAP_WIDE_VALUE ? null : value;
-            setSelectedFocusAreaId(newFocusAreaId);
             onFocusAreaSelect?.(newFocusAreaId);
         },
         [onFocusAreaSelect],
@@ -240,7 +240,7 @@ const AssetsView = ({ onClose, scenarioId, onFocusAreaSelect }: AssetsViewProps)
             .filter((category): category is ScenarioAssetCategory => category !== null);
     }, [assetCategories, deferredSearchQuery, filterSubCategories]);
 
-    const focusAreaSelectValue = selectedFocusAreaId ?? MAP_WIDE_VALUE;
+    const focusAreaSelectValue = currentFocusAreaId ?? MAP_WIDE_VALUE;
     const isMutating = visibilityMutation.isPending || clearAllMutation.isPending;
 
     if (!scenarioId) {

--- a/frontend/src/components/map-v2/panels/ExposureView.test.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.test.tsx
@@ -7,17 +7,26 @@ import type { Geometry } from 'geojson';
 
 import ExposureView from './ExposureView';
 import theme from '@/theme';
-import { fetchExposureLayers, type ExposureLayersResponse } from '@/api/exposure-layers';
+import { fetchExposureLayers, toggleExposureLayerVisibility, type ExposureLayersResponse } from '@/api/exposure-layers';
+import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
 
 vi.mock('@/api/exposure-layers', () => ({
     fetchExposureLayers: vi.fn(),
+    toggleExposureLayerVisibility: vi.fn(),
+}));
+
+vi.mock('@/api/focus-areas', () => ({
+    fetchFocusAreas: vi.fn(),
 }));
 
 const mockedFetchExposureLayers = vi.mocked(fetchExposureLayers);
+const mockedToggleExposureLayerVisibility = vi.mocked(toggleExposureLayerVisibility);
+const mockedFetchFocusAreas = vi.mocked(fetchFocusAreas);
 
 describe('ExposureView', () => {
     const defaultProps = {
         onClose: vi.fn(),
+        scenarioId: 'scenario-1',
     };
 
     let queryClient: QueryClient;
@@ -41,95 +50,92 @@ describe('ExposureView', () => {
         );
     };
 
-    const setupMocks = (options?: { exposureLayers?: ExposureLayersResponse }) => {
-        const mockGeometry1: Geometry = {
-            type: 'Polygon',
-            coordinates: [
-                [
-                    [-1.4, 50.67],
-                    [-1.4, 50.68],
-                    [-1.39, 50.68],
-                    [-1.39, 50.67],
-                    [-1.4, 50.67],
-                ],
+    const mockGeometry1: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.4, 50.67],
+                [-1.4, 50.68],
+                [-1.39, 50.68],
+                [-1.39, 50.67],
+                [-1.4, 50.67],
             ],
-        };
+        ],
+    };
 
-        const mockGeometry2: Geometry = {
-            type: 'Polygon',
-            coordinates: [
-                [
-                    [-1.3, 50.66],
-                    [-1.3, 50.67],
-                    [-1.29, 50.67],
-                    [-1.29, 50.66],
-                    [-1.3, 50.66],
-                ],
+    const mockGeometry2: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-1.3, 50.66],
+                [-1.3, 50.67],
+                [-1.29, 50.67],
+                [-1.29, 50.66],
+                [-1.3, 50.66],
             ],
-        };
+        ],
+    };
 
-        const {
-            exposureLayers = {
-                featureCollection: {
-                    type: 'FeatureCollection',
-                    features: [
-                        {
-                            type: 'Feature',
-                            id: '35a910f3-f611-4096-ac0b-0928c5612e32',
-                            geometry: mockGeometry1,
-                            properties: {
-                                name: 'Caul Bourne',
-                                groupId: '2d373dca-1337-4e60-ba08-c8326d27042d',
-                                groupName: 'Floods',
-                            },
-                        },
-                        {
-                            type: 'Feature',
-                            id: 'e34e3c22-a28f-45e5-99b5-a24b55ba875f',
-                            geometry: mockGeometry2,
-                            properties: {
-                                name: 'River Medina',
-                                groupId: '2d373dca-1337-4e60-ba08-c8326d27042d',
-                                groupName: 'Floods',
-                            },
-                        },
-                    ],
-                },
-                groups: [
-                    {
-                        id: '2d373dca-1337-4e60-ba08-c8326d27042d',
-                        name: 'Floods',
-                        exposureLayers: [
-                            {
-                                id: '35a910f3-f611-4096-ac0b-0928c5612e32',
-                                name: 'Caul Bourne',
-                                geometry: mockGeometry1,
-                            },
-                            {
-                                id: 'e34e3c22-a28f-45e5-99b5-a24b55ba875f',
-                                name: 'River Medina',
-                                geometry: mockGeometry2,
-                            },
-                        ],
+    const createMockExposureLayersResponse = (options?: { layers?: Array<{ id: string; name: string; isActive: boolean }> }): ExposureLayersResponse => {
+        const { layers = [] } = options || {};
+        return {
+            featureCollection: {
+                type: 'FeatureCollection',
+                features: layers.map((layer, index) => ({
+                    type: 'Feature',
+                    id: layer.id,
+                    geometry: index === 0 ? mockGeometry1 : mockGeometry2,
+                    properties: {
+                        name: layer.name,
+                        groupId: 'group-1',
+                        groupName: 'Floods',
+                        isActive: layer.isActive,
                     },
-                ],
+                })),
             },
+            groups: [
+                {
+                    id: 'group-1',
+                    name: 'Floods',
+                    exposureLayers: layers.map((layer, index) => ({
+                        id: layer.id,
+                        name: layer.name,
+                        geometry: index === 0 ? mockGeometry1 : mockGeometry2,
+                        isActive: layer.isActive,
+                    })),
+                },
+            ],
+        };
+    };
+
+    const mockFocusAreas: FocusArea[] = [
+        { id: 'fa-1', name: 'Focus Area 1', isActive: true, geometry: mockGeometry1 },
+        { id: 'fa-2', name: 'Focus Area 2', isActive: false, geometry: mockGeometry2 },
+    ];
+
+    const setupMocks = (options?: { exposureLayers?: ExposureLayersResponse; focusAreas?: FocusArea[] }) => {
+        const {
+            exposureLayers = createMockExposureLayersResponse({
+                layers: [
+                    { id: 'layer-1', name: 'Caul Bourne', isActive: false },
+                    { id: 'layer-2', name: 'River Medina', isActive: false },
+                ],
+            }),
+            focusAreas = mockFocusAreas,
         } = options || {};
 
         mockedFetchExposureLayers.mockResolvedValue(exposureLayers);
-    };
-
-    const waitForComponentReady = async () => {
-        await waitFor(() => {
-            expect(screen.getByText('Exposure')).toBeInTheDocument();
-        });
+        mockedFetchFocusAreas.mockResolvedValue(focusAreas);
+        mockedToggleExposureLayerVisibility.mockResolvedValue(undefined);
     };
 
     describe('Rendering', () => {
         it('renders title', async () => {
             setupMocks();
             renderWithProviders(<ExposureView {...defaultProps} />);
-            await waitForComponentReady();
+            await waitFor(() => {
+                expect(screen.getByText('Exposure')).toBeInTheDocument();
+            });
         });
 
         it('renders close button', async () => {
@@ -140,13 +146,101 @@ describe('ExposureView', () => {
             });
         });
 
+        it('shows no scenario message when scenarioId is not provided', () => {
+            renderWithProviders(<ExposureView onClose={vi.fn()} />);
+            expect(screen.getByText('No scenario selected')).toBeInTheDocument();
+        });
+
         it('shows loading state when layers are loading', async () => {
             const neverResolvingPromise = new Promise<never>(() => {});
             mockedFetchExposureLayers.mockImplementation(() => neverResolvingPromise as Promise<ExposureLayersResponse>);
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
                 expect(screen.getByText('Loading exposure layers...')).toBeInTheDocument();
             });
+        });
+    });
+
+    describe('Focus Area Dropdown', () => {
+        it('renders focus area dropdown', async () => {
+            setupMocks();
+            renderWithProviders(<ExposureView {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByLabelText('Focus area')).toBeInTheDocument();
+            });
+        });
+
+        it('shows Map wide as default option', async () => {
+            setupMocks();
+            renderWithProviders(<ExposureView {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByText('Map wide')).toBeInTheDocument();
+            });
+        });
+
+        it('calls onFocusAreaSelect when focus area is changed', async () => {
+            const onFocusAreaSelect = vi.fn();
+            setupMocks();
+            renderWithProviders(<ExposureView {...defaultProps} onFocusAreaSelect={onFocusAreaSelect} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Focus area')).toBeInTheDocument();
+            });
+
+            // Wait for focus areas to load
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            // Allow time for data to be processed
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 100);
+            });
+
+            const select = screen.getByRole('combobox');
+            fireEvent.mouseDown(select);
+
+            await waitFor(
+                () => {
+                    expect(screen.getByRole('option', { name: 'Focus Area 1' })).toBeInTheDocument();
+                },
+                { timeout: 2000 },
+            );
+
+            fireEvent.click(screen.getByRole('option', { name: 'Focus Area 1' }));
+
+            expect(onFocusAreaSelect).toHaveBeenCalledWith('fa-1');
+        });
+
+        it('disables inactive focus areas in dropdown', async () => {
+            setupMocks();
+            renderWithProviders(<ExposureView {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(screen.getByLabelText('Focus area')).toBeInTheDocument();
+            });
+
+            // Wait for focus areas to load
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            // Allow time for data to be processed
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 100);
+            });
+
+            const select = screen.getByRole('combobox');
+            fireEvent.mouseDown(select);
+
+            await waitFor(
+                () => {
+                    const inactiveOption = screen.getByRole('option', { name: 'Focus Area 2' });
+                    expect(inactiveOption).toHaveAttribute('aria-disabled', 'true');
+                },
+                { timeout: 2000 },
+            );
         });
     });
 
@@ -155,21 +249,14 @@ describe('ExposureView', () => {
             setupMocks();
         });
 
-        it('displays exposure layers grouped dynamically from API', async () => {
+        it('displays exposure layer groups', async () => {
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
                 expect(screen.getByText(/Floods/)).toBeInTheDocument();
             });
         });
 
-        it('shows group header', async () => {
-            renderWithProviders(<ExposureView {...defaultProps} />);
-            await waitFor(() => {
-                expect(screen.getByText(/Floods/)).toBeInTheDocument();
-            });
-        });
-
-        it('displays layer names when group is expanded', async () => {
+        it('shows layer names when group is expanded', async () => {
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
                 expect(screen.getByText(/Floods/)).toBeInTheDocument();
@@ -185,7 +272,26 @@ describe('ExposureView', () => {
             });
         });
 
-        it('sorts layers alphabetically', async () => {
+        it('shows "No exposure layers found" when there are no layers', async () => {
+            setupMocks({
+                exposureLayers: {
+                    featureCollection: { type: 'FeatureCollection', features: [] },
+                    groups: [],
+                },
+            });
+            renderWithProviders(<ExposureView {...defaultProps} />);
+            await waitFor(() => {
+                expect(screen.getByText('No exposure layers found')).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('Layer Toggle', () => {
+        beforeEach(() => {
+            setupMocks();
+        });
+
+        it('calls toggleExposureLayerVisibility when toggle is clicked', async () => {
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
                 expect(screen.getByText(/Floods/)).toBeInTheDocument();
@@ -196,25 +302,68 @@ describe('ExposureView', () => {
                 fireEvent.click(headerButton);
             }
             await waitFor(() => {
-                const layerNames = screen.getAllByText(/Caul Bourne|River Medina/);
-                expect(layerNames[0]).toHaveTextContent('Caul Bourne');
-                expect(layerNames[1]).toHaveTextContent('River Medina');
+                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
+            });
+
+            const toggle = screen.getByLabelText('Show Caul Bourne');
+            fireEvent.click(toggle);
+
+            await waitFor(() => {
+                expect(mockedToggleExposureLayerVisibility).toHaveBeenCalledWith('scenario-1', {
+                    exposureLayerId: 'layer-1',
+                    focusAreaId: null,
+                    isActive: true,
+                });
             });
         });
 
-        it('shows "No exposure layers found" when there are no layers', async () => {
+        it('passes correct focusAreaId when toggling in a focus area', async () => {
+            renderWithProviders(<ExposureView {...defaultProps} selectedFocusAreaId="fa-1" />);
+            await waitFor(() => {
+                expect(screen.getByText(/Floods/)).toBeInTheDocument();
+            });
+            const floodsHeader = screen.getByText(/Floods/);
+            const headerButton = floodsHeader.closest('button');
+            if (headerButton) {
+                fireEvent.click(headerButton);
+            }
+            await waitFor(() => {
+                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
+            });
+
+            const toggle = screen.getByLabelText('Show Caul Bourne');
+            fireEvent.click(toggle);
+
+            await waitFor(() => {
+                expect(mockedToggleExposureLayerVisibility).toHaveBeenCalledWith('scenario-1', {
+                    exposureLayerId: 'layer-1',
+                    focusAreaId: 'fa-1',
+                    isActive: true,
+                });
+            });
+        });
+
+        it('reflects visibility state from API response', async () => {
             setupMocks({
-                exposureLayers: {
-                    featureCollection: {
-                        type: 'FeatureCollection',
-                        features: [],
-                    },
-                    groups: [],
-                },
+                exposureLayers: createMockExposureLayersResponse({
+                    layers: [
+                        { id: 'layer-1', name: 'Caul Bourne', isActive: true },
+                        { id: 'layer-2', name: 'River Medina', isActive: false },
+                    ],
+                }),
             });
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
-                expect(screen.getByText('No exposure layers found')).toBeInTheDocument();
+                expect(screen.getByText(/Floods/)).toBeInTheDocument();
+            });
+            const floodsHeader = screen.getByText(/Floods/);
+            const headerButton = floodsHeader.closest('button');
+            if (headerButton) {
+                fireEvent.click(headerButton);
+            }
+            await waitFor(() => {
+                expect(screen.getByLabelText('Hide Caul Bourne')).toBeInTheDocument();
+                expect(screen.getByLabelText('Show River Medina')).toBeInTheDocument();
             });
         });
     });
@@ -237,7 +386,6 @@ describe('ExposureView', () => {
             }
             await waitFor(() => {
                 expect(headerButton).toHaveAttribute('aria-expanded', 'true');
-                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
             });
         });
 
@@ -248,15 +396,8 @@ describe('ExposureView', () => {
             });
             const floodsHeader = screen.getByText(/Floods/);
             const headerButton = floodsHeader.closest('button');
-            expect(headerButton).toHaveAttribute('aria-expanded', 'false');
             if (headerButton) {
                 fireEvent.click(headerButton);
-            }
-            await waitFor(() => {
-                expect(headerButton).toHaveAttribute('aria-expanded', 'true');
-                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
-            });
-            if (headerButton) {
                 fireEvent.click(headerButton);
             }
             await waitFor(() => {
@@ -264,188 +405,25 @@ describe('ExposureView', () => {
             });
         });
 
-        it('allows multiple groups to be expanded simultaneously', async () => {
+        it('auto-expands groups with active layers', async () => {
             setupMocks({
-                exposureLayers: {
-                    featureCollection: {
-                        type: 'FeatureCollection',
-                        features: [
-                            {
-                                type: 'Feature',
-                                id: 'layer-1',
-                                geometry: {
-                                    type: 'Polygon',
-                                    coordinates: [
-                                        [
-                                            [-1.4, 50.67],
-                                            [-1.4, 50.68],
-                                            [-1.39, 50.68],
-                                            [-1.39, 50.67],
-                                            [-1.4, 50.67],
-                                        ],
-                                    ],
-                                },
-                                properties: {
-                                    name: 'Layer 1',
-                                    groupId: 'group-1',
-                                    groupName: 'Floods',
-                                },
-                            },
-                            {
-                                type: 'Feature',
-                                id: 'layer-2',
-                                geometry: {
-                                    type: 'Polygon',
-                                    coordinates: [
-                                        [
-                                            [-1.3, 50.66],
-                                            [-1.3, 50.67],
-                                            [-1.29, 50.67],
-                                            [-1.29, 50.66],
-                                            [-1.3, 50.66],
-                                        ],
-                                    ],
-                                },
-                                properties: {
-                                    name: 'Layer 2',
-                                    groupId: 'group-2',
-                                    groupName: 'Environmentally sensitive areas',
-                                },
-                            },
-                        ],
-                    },
-                    groups: [
-                        {
-                            id: 'group-1',
-                            name: 'Floods',
-                            exposureLayers: [
-                                {
-                                    id: 'layer-1',
-                                    name: 'Layer 1',
-                                    geometry: {
-                                        type: 'Polygon',
-                                        coordinates: [
-                                            [
-                                                [-1.4, 50.67],
-                                                [-1.4, 50.68],
-                                                [-1.39, 50.68],
-                                                [-1.39, 50.67],
-                                                [-1.4, 50.67],
-                                            ],
-                                        ],
-                                    },
-                                },
-                            ],
-                        },
-                        {
-                            id: 'group-2',
-                            name: 'Environmentally sensitive areas',
-                            exposureLayers: [
-                                {
-                                    id: 'layer-2',
-                                    name: 'Layer 2',
-                                    geometry: {
-                                        type: 'Polygon',
-                                        coordinates: [
-                                            [
-                                                [-1.3, 50.66],
-                                                [-1.3, 50.67],
-                                                [-1.29, 50.67],
-                                                [-1.29, 50.66],
-                                                [-1.3, 50.66],
-                                            ],
-                                        ],
-                                    },
-                                },
-                            ],
-                        },
-                    ],
-                },
+                exposureLayers: createMockExposureLayersResponse({
+                    layers: [{ id: 'layer-1', name: 'Caul Bourne', isActive: true }],
+                }),
             });
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
-                expect(screen.getByText(/Floods/)).toBeInTheDocument();
-                expect(screen.getByText(/Environmentally sensitive areas/)).toBeInTheDocument();
+                const floodsHeader = screen.getByText(/Floods/);
+                const headerButton = floodsHeader.closest('button');
+                expect(headerButton).toHaveAttribute('aria-expanded', 'true');
             });
-            const floodsHeader = screen.getByText(/Floods/);
-            const envHeader = screen.getByText(/Environmentally sensitive areas/);
-            const floodsButton = floodsHeader.closest('button');
-            const envButton = envHeader.closest('button');
-            if (floodsButton) {
-                fireEvent.click(floodsButton);
-            }
-            if (envButton) {
-                fireEvent.click(envButton);
-            }
-            await waitFor(() => {
-                expect(screen.getByText('Layer 1')).toBeInTheDocument();
-                expect(screen.getByText('Layer 2')).toBeInTheDocument();
-            });
-        });
-    });
-
-    describe('Layer Toggle', () => {
-        beforeEach(() => {
-            setupMocks();
-        });
-
-        it('calls onExposureLayerToggle when toggle is clicked', async () => {
-            const onExposureLayerToggle = vi.fn();
-            renderWithProviders(<ExposureView {...defaultProps} onExposureLayerToggle={onExposureLayerToggle} />);
-            await waitFor(() => {
-                expect(screen.getByText(/Floods/)).toBeInTheDocument();
-            });
-            const floodsHeader = screen.getByText(/Floods/);
-            const headerButton = floodsHeader.closest('button');
-            if (headerButton) {
-                fireEvent.click(headerButton);
-            }
-            await waitFor(() => {
-                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
-            });
-            const toggleButtons = screen.getAllByRole('button').filter((button) => {
-                const listItem = button.closest('li');
-                return listItem?.textContent?.includes('Caul Bourne') && button.getAttribute('aria-label')?.includes('Caul Bourne');
-            });
-            expect(toggleButtons.length).toBeGreaterThan(0);
-            const toggle = toggleButtons[0];
-            fireEvent.click(toggle);
-            expect(onExposureLayerToggle).toHaveBeenCalledWith('35a910f3-f611-4096-ac0b-0928c5612e32', true);
-        });
-
-        it('reflects selected state from props', async () => {
-            renderWithProviders(
-                <ExposureView
-                    {...defaultProps}
-                    selectedExposureLayerIds={{ '35a910f3-f611-4096-ac0b-0928c5612e32': true, 'e34e3c22-a28f-45e5-99b5-a24b55ba875f': false }}
-                />,
-            );
-            await waitFor(() => {
-                expect(screen.getByText(/Floods/)).toBeInTheDocument();
-            });
-            const floodsHeader = screen.getByText(/Floods/);
-            const headerButton = floodsHeader.closest('button');
-            if (headerButton) {
-                fireEvent.click(headerButton);
-            }
-            await waitFor(() => {
-                expect(screen.getByText('Caul Bourne')).toBeInTheDocument();
-                expect(screen.getByText('River Medina')).toBeInTheDocument();
-            });
-            const toggle1 = screen.getByLabelText('Hide Caul Bourne');
-            const toggle2 = screen.getByLabelText('Show River Medina');
-            expect(toggle1).toBeInTheDocument();
-            expect(toggle2).toBeInTheDocument();
-            const visibilityIcon1 = toggle1.querySelector('svg[data-testid="VisibilityIcon"]');
-            const visibilityOffIcon2 = toggle2.querySelector('svg[data-testid="VisibilityOffIcon"]');
-            expect(visibilityIcon1).toBeInTheDocument();
-            expect(visibilityOffIcon2).toBeInTheDocument();
         });
     });
 
     describe('Error Handling', () => {
         it('displays error message when fetch fails', async () => {
             mockedFetchExposureLayers.mockRejectedValue(new Error('Network error'));
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
             renderWithProviders(<ExposureView {...defaultProps} />);
             await waitFor(() => {
                 expect(screen.getByText('Error loading exposure layers')).toBeInTheDocument();
@@ -459,11 +437,9 @@ describe('ExposureView', () => {
             setupMocks();
             renderWithProviders(<ExposureView {...defaultProps} onClose={onClose} />);
             await waitFor(() => {
-                const closeButton = screen.getByLabelText('Close panel');
-                expect(closeButton).toBeInTheDocument();
+                expect(screen.getByLabelText('Close panel')).toBeInTheDocument();
             });
-            const closeButton = screen.getByLabelText('Close panel');
-            fireEvent.click(closeButton);
+            fireEvent.click(screen.getByLabelText('Close panel'));
             expect(onClose).toHaveBeenCalledTimes(1);
         });
     });

--- a/frontend/src/components/map-v2/panels/ExposureView.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.tsx
@@ -1,18 +1,58 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { Box, IconButton, Typography, ListItem, ListItemText, Collapse, Button } from '@mui/material';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import {
+    Box,
+    IconButton,
+    Typography,
+    ListItem,
+    ListItemText,
+    Collapse,
+    Button,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    Alert,
+    Portal,
+    Snackbar,
+} from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Feature } from 'geojson';
 
-import { fetchExposureLayers } from '@/api/exposure-layers';
+import { fetchExposureLayers, toggleExposureLayerVisibility, type ExposureLayerGroup } from '@/api/exposure-layers';
+import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
 import IconToggle from '@/components/IconToggle';
+
+const MAP_WIDE_VALUE = '__map_wide__';
+
+const getGroupNamesWithActiveLayers = (groups: ExposureLayerGroup[]): Set<string> => {
+    const names = new Set<string>();
+    for (const group of groups) {
+        if (group.exposureLayers.some((layer) => layer.isActive)) {
+            names.add(group.name);
+        }
+    }
+    return names;
+};
+
+const buildLayerVisibilityMap = (groups: ExposureLayerGroup[]): Record<string, boolean> => {
+    const ids: Record<string, boolean> = {};
+    for (const group of groups) {
+        for (const layer of group.exposureLayers) {
+            ids[layer.id] = layer.isActive ?? false;
+        }
+    }
+    return ids;
+};
 
 type ExposureViewProps = {
     onClose: () => void;
-    selectedExposureLayerIds?: Record<string, boolean>;
-    onExposureLayerToggle?: (layerId: string, enabled: boolean) => void;
+    scenarioId?: string;
+    selectedFocusAreaId?: string | null;
+    onFocusAreaSelect?: (focusAreaId: string | null) => void;
 };
 
 type ExposureLayerListItemTextProps = {
@@ -37,9 +77,10 @@ type ExposureLayerListProps = {
     layers: Feature[];
     selectedExposureLayerIds: Record<string, boolean>;
     onToggle: (layerId: string) => void;
+    disabled?: boolean;
 };
 
-const ExposureLayerList = React.memo(({ layers, selectedExposureLayerIds, onToggle }: ExposureLayerListProps) => {
+const ExposureLayerList = React.memo(({ layers, selectedExposureLayerIds, onToggle, disabled }: ExposureLayerListProps) => {
     return (
         <Box sx={{ pl: 2, pr: 1, pb: 1 }}>
             {layers.map((layer) => {
@@ -65,6 +106,7 @@ const ExposureLayerList = React.memo(({ layers, selectedExposureLayerIds, onTogg
                         <IconToggle
                             checked={isSelected}
                             onChange={() => onToggle(layerId)}
+                            disabled={disabled}
                             aria-label={isSelected ? `Hide ${name}` : `Show ${name}`}
                             size="small"
                         />
@@ -84,9 +126,10 @@ type ExposureGroupProps = {
     selectedExposureLayerIds: Record<string, boolean>;
     onToggleGroup: (groupName: string) => void;
     onToggleLayer: (layerId: string) => void;
+    disabled?: boolean;
 };
 
-const ExposureGroup = React.memo(({ groupName, layers, isExpanded, selectedExposureLayerIds, onToggleGroup, onToggleLayer }: ExposureGroupProps) => {
+const ExposureGroup = React.memo(({ groupName, layers, isExpanded, selectedExposureLayerIds, onToggleGroup, onToggleLayer, disabled }: ExposureGroupProps) => {
     const handleToggle = useCallback(
         (e: React.MouseEvent | React.KeyboardEvent) => {
             e.stopPropagation();
@@ -134,7 +177,7 @@ const ExposureGroup = React.memo(({ groupName, layers, isExpanded, selectedExpos
             </Button>
 
             <Collapse in={isExpanded}>
-                <ExposureLayerList layers={layers} selectedExposureLayerIds={selectedExposureLayerIds} onToggle={onToggleLayer} />
+                <ExposureLayerList layers={layers} selectedExposureLayerIds={selectedExposureLayerIds} onToggle={onToggleLayer} disabled={disabled} />
             </Collapse>
         </Box>
     );
@@ -142,24 +185,55 @@ const ExposureGroup = React.memo(({ groupName, layers, isExpanded, selectedExpos
 
 ExposureGroup.displayName = 'ExposureGroup';
 
-const ExposureView = ({ onClose, selectedExposureLayerIds: externalSelectedExposureLayerIds = {}, onExposureLayerToggle }: ExposureViewProps) => {
+const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelect }: ExposureViewProps) => {
     const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-    const [localSelectedExposureLayerIds, setLocalSelectedExposureLayerIds] = useState<Record<string, boolean>>({});
+    const [mutationError, setMutationError] = useState<string | null>(null);
+    const queryClient = useQueryClient();
+    const currentFocusAreaId = selectedFocusAreaId ?? null;
 
-    const selectedExposureLayerIds = useMemo(
-        () => ({ ...localSelectedExposureLayerIds, ...externalSelectedExposureLayerIds }),
-        [localSelectedExposureLayerIds, externalSelectedExposureLayerIds],
-    );
+    const { data: focusAreas, isLoading: isLoadingFocusAreas } = useQuery({
+        queryKey: ['focusAreas', scenarioId],
+        queryFn: () => fetchFocusAreas(scenarioId!),
+        enabled: !!scenarioId,
+        staleTime: 5 * 60 * 1000,
+    });
 
     const {
         data: exposureLayersData,
         isLoading: isLoadingLayers,
         isError: isErrorLayers,
     } = useQuery({
-        queryKey: ['exposureLayers'],
-        queryFn: fetchExposureLayers,
-        staleTime: 5 * 60 * 1000,
+        queryKey: ['exposureLayers', scenarioId, currentFocusAreaId],
+        queryFn: () => fetchExposureLayers(scenarioId!, currentFocusAreaId),
+        enabled: !!scenarioId,
+        staleTime: 0,
+        refetchOnMount: true,
     });
+
+    const visibilityMutation = useMutation({
+        mutationFn: (data: { exposureLayerId: string; isActive: boolean }) => {
+            return toggleExposureLayerVisibility(scenarioId!, {
+                exposureLayerId: data.exposureLayerId,
+                focusAreaId: currentFocusAreaId,
+                isActive: data.isActive,
+            });
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['exposureLayers', scenarioId] });
+        },
+        onError: () => {
+            setMutationError('Failed to update exposure layer visibility');
+        },
+    });
+
+    useEffect(() => {
+        if (!exposureLayersData?.groups) {
+            return;
+        }
+
+        const groupNamesWithActiveLayers = getGroupNamesWithActiveLayers(exposureLayersData.groups);
+        setExpandedGroups((prev) => new Set([...prev, ...groupNamesWithActiveLayers]));
+    }, [exposureLayersData]);
 
     const toggleGroup = useCallback((groupName: string) => {
         setExpandedGroups((prev) => {
@@ -169,19 +243,22 @@ const ExposureView = ({ onClose, selectedExposureLayerIds: externalSelectedExpos
         });
     }, []);
 
+    const handleFocusAreaChange = useCallback(
+        (event: SelectChangeEvent<string>) => {
+            const value = event.target.value;
+            const newFocusAreaId = value === MAP_WIDE_VALUE ? null : value;
+            onFocusAreaSelect?.(newFocusAreaId);
+        },
+        [onFocusAreaSelect],
+    );
+
     const toggleExposureLayer = useCallback(
         (layerId: string) => {
-            const newState = !selectedExposureLayerIds[layerId];
-            setLocalSelectedExposureLayerIds((prev) => {
-                const updated = {
-                    ...prev,
-                    [layerId]: newState,
-                };
-                return updated;
-            });
-            onExposureLayerToggle?.(layerId, newState);
+            const currentState = exposureLayersData?.groups.flatMap((g) => g.exposureLayers).find((l) => l.id === layerId)?.isActive ?? false;
+            const newState = !currentState;
+            visibilityMutation.mutate({ exposureLayerId: layerId, isActive: newState });
         },
-        [selectedExposureLayerIds, onExposureLayerToggle],
+        [exposureLayersData, visibilityMutation],
     );
 
     const groupedLayers = useMemo(() => {
@@ -214,6 +291,34 @@ const ExposureView = ({ onClose, selectedExposureLayerIds: externalSelectedExpos
         return groups;
     }, [exposureLayersData]);
 
+    const selectedExposureLayerIds = useMemo(() => {
+        if (!exposureLayersData?.groups) {
+            return {};
+        }
+        return buildLayerVisibilityMap(exposureLayersData.groups);
+    }, [exposureLayersData]);
+
+    const focusAreaSelectValue = currentFocusAreaId ?? MAP_WIDE_VALUE;
+    const isMutating = visibilityMutation.isPending;
+
+    if (!scenarioId) {
+        return (
+            <Box sx={{ p: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                    <Typography variant="h6" fontWeight={600}>
+                        Exposure
+                    </Typography>
+                    <IconButton size="small" onClick={onClose} aria-label="Close panel">
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </Box>
+                <Typography variant="body2" color="text.secondary">
+                    No scenario selected
+                </Typography>
+            </Box>
+        );
+    }
+
     if (isErrorLayers) {
         return (
             <Box sx={{ p: 2 }}>
@@ -233,46 +338,81 @@ const ExposureView = ({ onClose, selectedExposureLayerIds: externalSelectedExpos
     }
 
     return (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', position: 'relative' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', p: 2, borderBottom: 1, borderColor: 'divider' }}>
-                <Typography variant="h6" fontWeight={600}>
-                    Exposure
-                </Typography>
-                <IconButton size="small" onClick={onClose} aria-label="Close panel">
-                    <CloseIcon fontSize="small" />
-                </IconButton>
+        <>
+            <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden', position: 'relative' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', p: 2, borderBottom: 1, borderColor: 'divider' }}>
+                    <Typography variant="h6" fontWeight={600}>
+                        Exposure
+                    </Typography>
+                    <IconButton size="small" onClick={onClose} aria-label="Close panel">
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </Box>
+
+                <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
+                    <FormControl fullWidth size="small">
+                        <InputLabel id="focus-area-select-label">Focus area</InputLabel>
+                        <Select
+                            labelId="focus-area-select-label"
+                            value={focusAreaSelectValue}
+                            onChange={handleFocusAreaChange}
+                            label="Focus area"
+                            disabled={isLoadingFocusAreas}
+                        >
+                            <MenuItem value={MAP_WIDE_VALUE}>Map wide</MenuItem>
+                            {focusAreas?.map((fa: FocusArea) => (
+                                <MenuItem key={fa.id} value={fa.id} disabled={!fa.isActive}>
+                                    {fa.name}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </Box>
+
+                <Box sx={{ flex: 1, overflowY: 'auto', position: 'relative' }}>
+                    {isLoadingLayers && (
+                        <Box sx={{ p: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                Loading exposure layers...
+                            </Typography>
+                        </Box>
+                    )}
+
+                    {!isLoadingLayers && Object.keys(groupedLayers).length === 0 && (
+                        <Box sx={{ p: 2 }}>
+                            <Typography variant="body2" color="text.secondary">
+                                No exposure layers found
+                            </Typography>
+                        </Box>
+                    )}
+
+                    {Object.entries(groupedLayers).map(([groupId, groupData]) => (
+                        <ExposureGroup
+                            key={groupId}
+                            groupName={groupData.name}
+                            layers={groupData.layers}
+                            isExpanded={expandedGroups.has(groupData.name)}
+                            selectedExposureLayerIds={selectedExposureLayerIds}
+                            onToggleGroup={toggleGroup}
+                            onToggleLayer={toggleExposureLayer}
+                            disabled={isMutating}
+                        />
+                    ))}
+                </Box>
             </Box>
-
-            <Box sx={{ flex: 1, overflowY: 'auto', position: 'relative' }}>
-                {isLoadingLayers && (
-                    <Box sx={{ p: 2 }}>
-                        <Typography variant="body2" color="text.secondary">
-                            Loading exposure layers...
-                        </Typography>
-                    </Box>
-                )}
-
-                {!isLoadingLayers && Object.keys(groupedLayers).length === 0 && (
-                    <Box sx={{ p: 2 }}>
-                        <Typography variant="body2" color="text.secondary">
-                            No exposure layers found
-                        </Typography>
-                    </Box>
-                )}
-
-                {Object.entries(groupedLayers).map(([groupId, groupData]) => (
-                    <ExposureGroup
-                        key={groupId}
-                        groupName={groupData.name}
-                        layers={groupData.layers}
-                        isExpanded={expandedGroups.has(groupData.name)}
-                        selectedExposureLayerIds={selectedExposureLayerIds}
-                        onToggleGroup={toggleGroup}
-                        onToggleLayer={toggleExposureLayer}
-                    />
-                ))}
-            </Box>
-        </Box>
+            <Portal>
+                <Snackbar
+                    open={!!mutationError}
+                    autoHideDuration={6000}
+                    onClose={() => setMutationError(null)}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                >
+                    <Alert onClose={() => setMutationError(null)} severity="error" sx={{ width: '100%' }}>
+                        {mutationError}
+                    </Alert>
+                </Snackbar>
+            </Portal>
+        </>
     );
 };
 


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-1986
https://ndtp.atlassian.net/browse/DPAV-2192

## Screenshots (if appropriate):

<img width="1581" height="1181" alt="Screenshot 2025-12-18 at 00 47 13" src="https://github.com/user-attachments/assets/0dbb51e8-a135-4ac7-9c5b-b79ba66b0b94" />

<img width="1581" height="1181" alt="Screenshot 2025-12-18 at 00 47 31" src="https://github.com/user-attachments/assets/f73ddfdd-e224-4ba5-a84b-ec12e6244bcf" />

<img width="1581" height="1181" alt="Screenshot 2025-12-18 at 00 47 58" src="https://github.com/user-attachments/assets/f7e1ba6a-7c64-4bee-8ab1-45646798c481" />

## Checklist:

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
