### PR TITLE
feat(DPAV-1786): Update exposure layers for with Map-wide FocusArea

### DIFF
--- a/backend/vista-python-api/src/api/migrations/0034_visible_exposure_layer_data_migration.py
+++ b/backend/vista-python-api/src/api/migrations/0034_visible_exposure_layer_data_migration.py
@@ -1,0 +1,64 @@
+"""Migrate VisibleExposureLayer data to use FocusArea."""
+
+from typing import ClassVar
+
+from django.db import migrations
+
+
+def create_mapwide_focus_areas_for_exposure_layers(apps, _schema_editor):
+    """Create map-wide FocusArea for (scenario, user_id) with NULL focus_area."""
+    FocusArea = apps.get_model("api", "FocusArea")
+    VisibleExposureLayer = apps.get_model("api", "VisibleExposureLayer")
+
+    # Find all unique (scenario_id, user_id) combinations with null focus_area
+    mapwide_combos = (
+        VisibleExposureLayer.objects.filter(focus_area__isnull=True)
+        .values("scenario_id", "user_id")
+        .distinct()
+    )
+
+    for combo in mapwide_combos:
+        scenario_id = combo["scenario_id"]
+        user_id = combo["user_id"]
+
+        # Check if a map-wide focus area already exists for this user/scenario
+        existing_mapwide = FocusArea.objects.filter(
+            scenario_id=scenario_id,
+            user_id=user_id,
+            is_system=True,
+        ).first()
+
+        if existing_mapwide:
+            # Use existing map-wide focus area
+            fa_id = existing_mapwide.id
+        else:
+            # Create new map-wide focus area
+            fa = FocusArea.objects.create(
+                scenario_id=scenario_id,
+                user_id=user_id,
+                name="Map-wide",
+                geometry=None,
+                filter_mode="by_asset_type",
+                is_active=True,
+                is_system=True,
+            )
+            fa_id = fa.id
+
+        # Update VisibleExposureLayers to point to the map-wide FocusArea
+        VisibleExposureLayer.objects.filter(
+            scenario_id=scenario_id, user_id=user_id, focus_area__isnull=True
+        ).update(focus_area_id=fa_id)
+
+
+class Migration(migrations.Migration):
+    """Migrate VisibleExposureLayer data to use FocusArea."""
+
+    dependencies: ClassVar = [
+        ("api", "0033_score_filtering_part2"),
+    ]
+
+    operations: ClassVar = [
+        migrations.RunPython(
+            create_mapwide_focus_areas_for_exposure_layers, migrations.RunPython.noop
+        ),
+    ]

--- a/backend/vista-python-api/src/api/migrations/0035_visible_exposure_layer_schema.py
+++ b/backend/vista-python-api/src/api/migrations/0035_visible_exposure_layer_schema.py
@@ -1,0 +1,49 @@
+"""Update VisibleExposureLayer schema to use FocusArea instead of scenario/user_id."""
+
+from typing import ClassVar
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Update VisibleExposureLayer schema to use FocusArea instead of scenario/user_id."""
+
+    dependencies: ClassVar = [
+        ("api", "0034_visible_exposure_layer_data_migration"),
+    ]
+
+    operations: ClassVar = [
+        # Remove old unique constraint that includes scenario and user_id
+        migrations.RemoveConstraint(
+            model_name="visibleexposurelayer",
+            name="unique_visible_exposure_layer",
+        ),
+        # Remove scenario and user_id fields from VisibleExposureLayer
+        migrations.RemoveField(
+            model_name="visibleexposurelayer",
+            name="scenario",
+        ),
+        migrations.RemoveField(
+            model_name="visibleexposurelayer",
+            name="user_id",
+        ),
+        # Make focus_area non-nullable on VisibleExposureLayer
+        migrations.AlterField(
+            model_name="visibleexposurelayer",
+            name="focus_area",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="visible_exposure_layers",
+                to="api.focusarea",
+            ),
+        ),
+        # Add new unique constraint for VisibleExposureLayer (focus_area + exposure_layer)
+        migrations.AddConstraint(
+            model_name="visibleexposurelayer",
+            constraint=models.UniqueConstraint(
+                fields=["focus_area", "exposure_layer"],
+                name="unique_visible_exposure_layer",
+            ),
+        ),
+    ]

--- a/backend/vista-python-api/src/api/migrations/0036_update_asset_score_views_for_focus_area.py
+++ b/backend/vista-python-api/src/api/migrations/0036_update_asset_score_views_for_focus_area.py
@@ -1,0 +1,98 @@
+"""Update asset score views to use focus_area relationship."""
+
+from typing import ClassVar
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Update views to join through focus_area instead of direct user_id/scenario_id."""
+
+    dependencies: ClassVar = [
+        ("api", "0035_visible_exposure_layer_schema"),
+    ]
+
+    operations: ClassVar = [
+        migrations.RunSQL(
+            sql="""
+                DROP VIEW IF EXISTS public.asset_scores;
+                DROP VIEW IF EXISTS public.visible_exposure_asset_scores;
+                CREATE VIEW public.visible_exposure_asset_scores AS
+                     WITH active_exposure_layers AS (
+                        SELECT ael.asset_id,
+                            fa.user_id,
+                            fa.scenario_id,
+                            ael.exposure_layer_id,
+                            ael.intersects
+                        FROM assets_within_500m_exposure_layers ael
+                            JOIN api_visibleexposurelayer ve
+                                ON ael.exposure_layer_id = ve.exposure_layer_id
+                            JOIN api_focusarea fa
+                                ON ve.focus_area_id = fa.id
+                        ), agg AS (
+                        SELECT active_exposure_layers.asset_id,
+                            active_exposure_layers.user_id,
+                            active_exposure_layers.scenario_id,
+                            count(*) FILTER (WHERE active_exposure_layers.intersects) AS inter_ct,
+                            count(*) FILTER (WHERE NOT active_exposure_layers.intersects) AS near_ct
+                        FROM active_exposure_layers
+                        GROUP BY active_exposure_layers.asset_id, active_exposure_layers.user_id,
+                            active_exposure_layers.scenario_id
+                        )
+                SELECT asset_id,
+                    user_id,
+                    scenario_id,
+                        CASE
+                            WHEN inter_ct > 1 THEN 3
+                            WHEN inter_ct = 1 THEN 2
+                            WHEN near_ct >= 1 THEN 1
+                            ELSE 0
+                        END AS score
+                FROM agg;
+            """,
+            reverse_sql="""
+                DROP VIEW IF EXISTS public.visible_exposure_asset_scores;
+            """,
+        ),
+        # No changes to asset_scores view, same as before.
+        migrations.RunSQL(
+            sql="""
+                CREATE VIEW public.asset_scores AS
+                     SELECT a.id,
+                        s_a.scenario_id,
+                        exposure.user_id,
+                        s_a.criticality_score,
+                        COALESCE(avg(dep_score.score), 0::numeric) AS dependency_score,
+                        COALESCE(exposure.score, 0) AS exposure_score,
+                        3 AS redundancy_score
+                    FROM api_scenarioasset s_a
+                        LEFT JOIN api_asset a ON a.type_id = s_a.asset_type_id
+                        LEFT JOIN ( SELECT a_d.provider_asset_id AS id,
+                                s_a_1.criticality_score AS score,
+                                s_a_1.scenario_id AS scenario_id
+                            FROM api_dependency a_d
+                                LEFT JOIN api_asset a_1 ON a_d.dependent_asset_id = a_1.external_id
+                                LEFT JOIN api_scenarioasset s_a_1
+                                    ON s_a_1.asset_type_id = a_1.type_id) dep_score
+                                ON dep_score.id = a.external_id
+                                    AND dep_score.scenario_id = s_a.scenario_id
+                        LEFT JOIN ( SELECT veas.asset_id,
+                                veas.user_id,
+                                veas.scenario_id,
+                                veas.score
+                            FROM visible_exposure_asset_scores veas
+                            UNION ALL
+                            SELECT veas.asset_id,
+                                NULL::uuid AS user_id,
+                                veas.scenario_id,
+                                0 AS score
+                            FROM visible_exposure_asset_scores veas) exposure
+                            ON exposure.asset_id = a.id AND exposure.scenario_id = s_a.scenario_id
+                    GROUP BY a.id, s_a.scenario_id, exposure.user_id, s_a.criticality_score,
+                        exposure.score;
+            """,
+            reverse_sql="""
+                DROP VIEW IF EXISTS public.asset_scores;
+            """,
+        ),
+    ]

--- a/backend/vista-python-api/src/api/models/visible_exposure_layer.py
+++ b/backend/vista-python-api/src/api/models/visible_exposure_layer.py
@@ -7,27 +7,19 @@ from django.db import models
 
 from .exposure_layer import ExposureLayer
 from .focus_area import FocusArea
-from .scenario import Scenario
 
 
 class VisibleExposureLayer(models.Model):
-    """Tracks which exposure layers are visible for a user within a scenario/focus area.
+    """Tracks which exposure layers are visible within a focus area scope.
 
     Row existence indicates visibility. To hide an exposure layer, delete the row.
-    focus_area_id = NULL indicates map-wide/global visibility.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    scenario = models.ForeignKey(
-        Scenario, on_delete=models.CASCADE, related_name="visible_exposure_layers"
-    )
-    user_id = models.UUIDField(db_index=True)
     focus_area = models.ForeignKey(
         FocusArea,
         on_delete=models.CASCADE,
         related_name="visible_exposure_layers",
-        null=True,
-        blank=True,
     )
     exposure_layer = models.ForeignKey(
         ExposureLayer, on_delete=models.CASCADE, related_name="visible_in"
@@ -38,12 +30,11 @@ class VisibleExposureLayer(models.Model):
 
         constraints: ClassVar[list[models.UniqueConstraint]] = [
             models.UniqueConstraint(
-                fields=["scenario", "user_id", "focus_area", "exposure_layer"],
+                fields=["focus_area", "exposure_layer"],
                 name="unique_visible_exposure_layer",
             )
         ]
 
     def __str__(self):
         """Return string representation."""
-        area = self.focus_area.name if self.focus_area else "Map-wide"
-        return f"{self.exposure_layer.name} visible in {area} ({self.scenario.name})"
+        return f"{self.exposure_layer.name} visible in {self.focus_area.name}"

--- a/backend/vista-python-api/src/api/serializers/visible_exposure_layers.py
+++ b/backend/vista-python-api/src/api/serializers/visible_exposure_layers.py
@@ -7,7 +7,7 @@ class VisibleExposureLayerToggleSerializer(serializers.Serializer):
     """Serializer for toggling exposure layer visibility."""
 
     exposure_layer_id = serializers.UUIDField()
-    focus_area_id = serializers.UUIDField(required=False, allow_null=True)
+    focus_area_id = serializers.UUIDField()
     is_active = serializers.BooleanField()
 
 
@@ -15,5 +15,5 @@ class VisibleExposureLayerResponseSerializer(serializers.Serializer):
     """Serializer for the visibility toggle response."""
 
     exposure_layer_id = serializers.UUIDField()
-    focus_area_id = serializers.UUIDField(allow_null=True)
+    focus_area_id = serializers.UUIDField()
     is_active = serializers.BooleanField()

--- a/backend/vista-python-api/src/api/sql/visible_exposure_asset_scores.sql
+++ b/backend/vista-python-api/src/api/sql/visible_exposure_asset_scores.sql
@@ -1,12 +1,13 @@
 CREATE VIEW public.visible_exposure_asset_scores AS
         WITH active_exposure_layers AS (
         SELECT ael.asset_id,
-            ve.user_id,
-            ve.scenario_id,
+            fa.user_id,
+            fa.scenario_id,
             ael.exposure_layer_id,
             ael.intersects
         FROM assets_within_500m_exposure_layers ael
             JOIN api_visibleexposurelayer ve ON ael.exposure_layer_id = ve.exposure_layer_id
+            JOIN api_focusarea fa ON ve.focus_area_id = fa.id
         ), agg AS (
         SELECT active_exposure_layers.asset_id,
             active_exposure_layers.user_id,

--- a/backend/vista-python-api/src/api/tests/views/test_asset_scores.py
+++ b/backend/vista-python-api/src/api/tests/views/test_asset_scores.py
@@ -16,6 +16,7 @@ from api.models import (
     Dependency,
     ExposureLayer,
     ExposureLayerType,
+    FocusArea,
     Scenario,
     ScenarioAsset,
     VisibleExposureLayer,
@@ -65,7 +66,7 @@ def _get_exposure_score_for_asset(fixture, asset_id, scenario_id):
     in_count = 0
     near_count = 0
     for exposure_layer in fixture["exposure_layers"]:
-        if scenario_id != exposure_layer.scenario.id:
+        if scenario_id != exposure_layer.focus_area.scenario.id:
             continue
         poly_m = exposure_layer.exposure_layer.geometry.transform(3857, clone=True)
         pt_m = asset.geom.transform(3857, clone=True)
@@ -147,8 +148,16 @@ def fixture(db):  # noqa: ARG001
     exposure_layer_type = ExposureLayerType.objects.create(name="Flood")
     ExposureLayer.objects.create(geometry=poly, type=exposure_layer_type)
     exposure_layer = ExposureLayer.objects.create(geometry=poly, type=exposure_layer_type)
+    focus_area = FocusArea.objects.create(
+        scenario=scenario1,
+        user_id=user_id,
+        name="Map-wide",
+        geometry=None,
+        is_system=True,
+        is_active=True,
+    )
     vis_exposure_layer = VisibleExposureLayer.objects.create(
-        scenario=scenario1, exposure_layer=exposure_layer, user_id=user_id
+        focus_area=focus_area, exposure_layer=exposure_layer
     )
 
     scenario_asset_1 = ScenarioAsset.objects.create(

--- a/backend/vista-python-api/src/api/tests/views/test_visible_exposure_layers.py
+++ b/backend/vista-python-api/src/api/tests/views/test_visible_exposure_layers.py
@@ -1,4 +1,4 @@
-"""Tests for the visible asset types endpoint."""
+"""Tests for the visible exposure layers endpoint."""
 
 import json
 import uuid
@@ -10,6 +10,7 @@ from api.models import FocusArea, Scenario, VisibleExposureLayer
 from api.models.exposure_layer import ExposureLayer, ExposureLayerType
 
 http_success_code = 200
+http_bad_request = 400
 http_not_found = 404
 
 
@@ -50,30 +51,6 @@ def focus_area(db, scenario):  # noqa: ARG001
 
 
 @pytest.mark.django_db
-def test_enable_exposure_layer_map_wide(scenario, exposure_layer, client):
-    """Test enabling an exposure layer type map-wide (no focus area)."""
-    response = client.put(
-        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
-        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": True}),
-        content_type="application/json",
-    )
-    data = response.json()
-
-    assert response.status_code == http_success_code
-    assert data["exposureLayerId"] == str(exposure_layer.id)
-    assert data["focusAreaId"] is None
-    assert data["isActive"] is True
-
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
-    assert VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area__isnull=True,
-        exposure_layer=exposure_layer,
-    ).exists()
-
-
-@pytest.mark.django_db
 def test_enable_exposure_layer_for_focus_area(scenario, exposure_layer, focus_area, client):
     """Test enabling an exposure layer for a specific focus area."""
     response = client.put(
@@ -90,32 +67,61 @@ def test_enable_exposure_layer_for_focus_area(scenario, exposure_layer, focus_ar
     data = response.json()
 
     assert response.status_code == http_success_code
+    assert data["exposureLayerId"] == str(exposure_layer.id)
     assert data["focusAreaId"] == str(focus_area.id)
     assert data["isActive"] is True
 
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
     assert VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
         focus_area=focus_area,
         exposure_layer=exposure_layer,
     ).exists()
 
 
 @pytest.mark.django_db
-def test_disable_exposure_layer_deletes_record(scenario, exposure_layer, client):
-    """Test that disabling an asset type deletes the VisibleExposureLayer record."""
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+def test_enable_exposure_layer_for_mapwide_focus_area(
+    scenario, exposure_layer, mapwide_focus_area, client
+):
+    """Test enabling an exposure layer for the map-wide focus area."""
+    response = client.put(
+        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
+        data=json.dumps(
+            {
+                "exposureLayerId": str(exposure_layer.id),
+                "focusAreaId": str(mapwide_focus_area.id),
+                "isActive": True,
+            }
+        ),
+        content_type="application/json",
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    assert data["focusAreaId"] == str(mapwide_focus_area.id)
+    assert data["isActive"] is True
+
+    assert VisibleExposureLayer.objects.filter(
+        focus_area=mapwide_focus_area,
+        exposure_layer=exposure_layer,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_disable_exposure_layer_deletes_record(scenario, exposure_layer, focus_area, client):
+    """Test that disabling an exposure layer deletes the VisibleExposureLayer record."""
     VisibleExposureLayer.objects.create(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area=None,
+        focus_area=focus_area,
         exposure_layer=exposure_layer,
     )
 
     response = client.put(
         f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
-        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": False}),
+        data=json.dumps(
+            {
+                "exposureLayerId": str(exposure_layer.id),
+                "focusAreaId": str(focus_area.id),
+                "isActive": False,
+            }
+        ),
         content_type="application/json",
     )
     data = response.json()
@@ -123,38 +129,45 @@ def test_disable_exposure_layer_deletes_record(scenario, exposure_layer, client)
     assert response.status_code == http_success_code
     assert data["isActive"] is False
     assert not VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area__isnull=True,
+        focus_area=focus_area,
         exposure_layer=exposure_layer,
     ).exists()
 
 
 @pytest.mark.django_db
-def test_enable_is_idempotent(scenario, exposure_layer, client):
+def test_enable_is_idempotent(scenario, exposure_layer, focus_area, client):
     """Test that enabling twice doesn't create duplicates."""
     url = f"/api/scenarios/{scenario.id}/visible-exposure-layers/"
-    payload = json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": True})
+    payload = json.dumps(
+        {
+            "exposureLayerId": str(exposure_layer.id),
+            "focusAreaId": str(focus_area.id),
+            "isActive": True,
+        }
+    )
 
     client.put(url, data=payload, content_type="application/json")
     client.put(url, data=payload, content_type="application/json")
 
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
     count = VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area__isnull=True,
+        focus_area=focus_area,
         exposure_layer=exposure_layer,
     ).count()
     assert count == 1
 
 
 @pytest.mark.django_db
-def test_disable_nonexistent_is_noop(scenario, exposure_layer, client):
-    """Test that disabling a non-visible asset type is a no-op."""
+def test_disable_nonexistent_is_noop(scenario, exposure_layer, focus_area, client):
+    """Test that disabling a non-visible exposure layer is a no-op."""
     response = client.put(
         f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
-        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": False}),
+        data=json.dumps(
+            {
+                "exposureLayerId": str(exposure_layer.id),
+                "focusAreaId": str(focus_area.id),
+                "isActive": False,
+            }
+        ),
         content_type="application/json",
     )
 
@@ -162,9 +175,32 @@ def test_disable_nonexistent_is_noop(scenario, exposure_layer, client):
 
 
 @pytest.mark.django_db
-def test_scenario_exposure_layers_with_visibility(scenario, exposure_layer, client):
-    """Test scenario asset types endpoint returns nested structure with isActive."""
+def test_toggle_requires_focus_area_id(scenario, exposure_layer, client):
+    """Test that focus_area_id is required for toggling visibility."""
+    response = client.put(
+        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
+        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": True}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_bad_request
+
+
+@pytest.mark.django_db
+def test_scenario_exposure_layers_requires_focus_area_id(scenario, client):
+    """Test that focus_area_id query param is required for listing exposure layers."""
     response = client.get(f"/api/scenarios/{scenario.id}/exposure-layers/")
+
+    assert response.status_code == http_bad_request
+    assert "focus_area_id" in response.json().get("error", "")
+
+
+@pytest.mark.django_db
+def test_scenario_exposure_layers_with_visibility(scenario, exposure_layer, focus_area, client):
+    """Test scenario exposure layers endpoint returns nested structure with isActive."""
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={focus_area.id}"
+    )
     data = response.json()
 
     assert response.status_code == http_success_code
@@ -182,24 +218,8 @@ def test_scenario_exposure_layers_with_visibility(scenario, exposure_layer, clie
 
 
 @pytest.mark.django_db
-def test_scenario_exposure_layers_after_enable(scenario, exposure_layer, client):
+def test_scenario_exposure_layers_after_enable(scenario, exposure_layer, focus_area, client):
     """Test isActive is true after enabling visibility."""
-    client.put(
-        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
-        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": True}),
-        content_type="application/json",
-    )
-
-    response = client.get(f"/api/scenarios/{scenario.id}/exposure-layers/")
-    data = response.json()
-
-    exposure_layer_data = find_exposure_layer_in_tree(data, exposure_layer.id)
-    assert exposure_layer_data["isActive"] is True
-
-
-@pytest.mark.django_db
-def test_scenario_exposure_layers_with_focus_area(scenario, exposure_layer, focus_area, client):
-    """Test getting visibility for specific focus area."""
     client.put(
         f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
         data=json.dumps(
@@ -220,7 +240,37 @@ def test_scenario_exposure_layers_with_focus_area(scenario, exposure_layer, focu
     exposure_layer_data = find_exposure_layer_in_tree(data, exposure_layer.id)
     assert exposure_layer_data["isActive"] is True
 
-    response_map_wide = client.get(f"/api/scenarios/{scenario.id}/exposure-layers/")
+
+@pytest.mark.django_db
+def test_scenario_exposure_layers_visibility_is_per_focus_area(
+    scenario, exposure_layer, focus_area, mapwide_focus_area, client
+):
+    """Test that visibility is scoped to focus area."""
+    # Enable for specific focus area
+    client.put(
+        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
+        data=json.dumps(
+            {
+                "exposureLayerId": str(exposure_layer.id),
+                "focusAreaId": str(focus_area.id),
+                "isActive": True,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Should be visible in focus area
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+    exposure_layer_data = find_exposure_layer_in_tree(data, exposure_layer.id)
+    assert exposure_layer_data["isActive"] is True
+
+    # Should NOT be visible in map-wide
+    response_map_wide = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={mapwide_focus_area.id}"
+    )
     data_map_wide = response_map_wide.json()
     exposure_layer_data_map = find_exposure_layer_in_tree(data_map_wide, exposure_layer.id)
     assert exposure_layer_data_map["isActive"] is False
@@ -230,75 +280,26 @@ def test_scenario_exposure_layers_with_focus_area(scenario, exposure_layer, focu
 def test_scenario_exposure_layers_invalid_scenario(client):
     """Test that invalid scenario returns 404."""
     fake_id = uuid.uuid4()
-    response = client.get(f"/api/scenarios/{fake_id}/exposure-layers/")
+    response = client.get(f"/api/scenarios/{fake_id}/exposure-layers/?focus_area_id={fake_id}")
     assert response.status_code == http_not_found
 
 
 @pytest.mark.django_db
-def test_disable_map_wide_does_not_affect_focus_area(scenario, exposure_layer, focus_area, client):
-    """Test that disabling map-wide visibility doesn't delete focus-area-specific visibility."""
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
-
-    # Enable both map-wide and focus-area-specific
+def test_disable_focus_area_does_not_affect_other_focus_areas(
+    scenario, exposure_layer, focus_area, mapwide_focus_area, client
+):
+    """Test that disabling visibility for one focus area doesn't affect others."""
+    # Enable for both focus areas
     VisibleExposureLayer.objects.create(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area=None,
-        exposure_layer=exposure_layer,
-    )
-    VisibleExposureLayer.objects.create(
-        scenario=scenario,
-        user_id=mock_user_id,
         focus_area=focus_area,
         exposure_layer=exposure_layer,
     )
-
-    # Disable map-wide
-    response = client.put(
-        f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
-        data=json.dumps({"exposureLayerId": str(exposure_layer.id), "isActive": False}),
-        content_type="application/json",
-    )
-
-    assert response.status_code == http_success_code
-
-    # Map-wide should be deleted
-    assert not VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area__isnull=True,
-        exposure_layer=exposure_layer,
-    ).exists()
-
-    # Focus-area-specific should still exist
-    assert VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area=focus_area,
-        exposure_layer=exposure_layer,
-    ).exists()
-
-
-@pytest.mark.django_db
-def test_disable_focus_area_does_not_affect_map_wide(scenario, exposure_layer, focus_area, client):
-    """Test that disabling focus-area visibility doesn't delete map-wide visibility."""
-    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
-
-    # Enable both map-wide and focus-area-specific
     VisibleExposureLayer.objects.create(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area=None,
-        exposure_layer=exposure_layer,
-    )
-    VisibleExposureLayer.objects.create(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area=focus_area,
+        focus_area=mapwide_focus_area,
         exposure_layer=exposure_layer,
     )
 
-    # Disable focus-area-specific
+    # Disable for focus area
     response = client.put(
         f"/api/scenarios/{scenario.id}/visible-exposure-layers/",
         data=json.dumps(
@@ -313,18 +314,149 @@ def test_disable_focus_area_does_not_affect_map_wide(scenario, exposure_layer, f
 
     assert response.status_code == http_success_code
 
-    # Focus-area-specific should be deleted
+    # Focus area should be deleted
     assert not VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
         focus_area=focus_area,
         exposure_layer=exposure_layer,
     ).exists()
 
     # Map-wide should still exist
     assert VisibleExposureLayer.objects.filter(
-        scenario=scenario,
-        user_id=mock_user_id,
-        focus_area__isnull=True,
+        focus_area=mapwide_focus_area,
         exposure_layer=exposure_layer,
     ).exists()
+
+
+@pytest.mark.django_db
+def test_exposure_layers_filtered_by_focus_area_geometry(scenario, client):
+    """Test that only exposure layers intersecting focus area geometry are returned."""
+    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    # Create exposure layer type
+    exposure_layer_type = ExposureLayerType.objects.create(id=uuid.uuid4(), name="Floods")
+
+    # Create exposure layer inside the focus area (0,0 to 1,1)
+    inside_geom = GEOSGeometry("POLYGON((0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))")
+    inside_layer = ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Inside Layer", geometry=inside_geom, type=exposure_layer_type
+    )
+
+    # Create exposure layer outside the focus area
+    outside_geom = GEOSGeometry("POLYGON((5 5, 5 6, 6 6, 6 5, 5 5))")
+    ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Outside Layer", geometry=outside_geom, type=exposure_layer_type
+    )
+
+    # Create focus area with geometry
+    focus_area_geom = GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
+    focus_area = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Test Focus Area",
+        geometry=focus_area_geom,
+        filter_mode="by_asset_type",
+        is_active=True,
+        is_system=False,
+    )
+
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+
+    # Should find the inside layer
+    inside_layer_data = find_exposure_layer_in_tree(data, inside_layer.id)
+    assert inside_layer_data is not None
+
+    # Should NOT find the outside layer (filtered out by geometry)
+    all_layer_ids = [el["id"] for elt in data for el in elt.get("exposureLayers", [])]
+
+    assert str(inside_layer.id) in all_layer_ids
+    # Outside layer should not be in results - count should only include inside layer
+    assert len(all_layer_ids) == 1
+
+
+@pytest.mark.django_db
+def test_empty_exposure_layer_types_have_empty_arrays(scenario, client):
+    """Test that exposure layer types with no layers have empty exposureLayers arrays."""
+    mock_user_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+    # Create two exposure layer types
+    type_with_layers = ExposureLayerType.objects.create(id=uuid.uuid4(), name="With Layers")
+    type_without_layers = ExposureLayerType.objects.create(id=uuid.uuid4(), name="Without Layers")
+
+    # Create exposure layer inside the focus area for first type
+    inside_geom = GEOSGeometry("POLYGON((0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))")
+    ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Inside Layer", geometry=inside_geom, type=type_with_layers
+    )
+
+    # Create exposure layer outside the focus area for second type
+    outside_geom = GEOSGeometry("POLYGON((5 5, 5 6, 6 6, 6 5, 5 5))")
+    ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Outside Layer", geometry=outside_geom, type=type_without_layers
+    )
+
+    # Create focus area with geometry
+    focus_area_geom = GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
+    focus_area = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Test Focus Area",
+        geometry=focus_area_geom,
+        filter_mode="by_asset_type",
+        is_active=True,
+        is_system=False,
+    )
+
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+
+    # Both types should be present
+    types_by_name = {t["name"]: t for t in data}
+    assert "With Layers" in types_by_name
+    assert "Without Layers" in types_by_name
+
+    # Type with layers inside focus area should have layers
+    assert len(types_by_name["With Layers"]["exposureLayers"]) == 1
+
+    # Type with layers outside focus area should have empty array
+    assert len(types_by_name["Without Layers"]["exposureLayers"]) == 0
+
+
+@pytest.mark.django_db
+def test_mapwide_focus_area_returns_all_exposure_layers(scenario, mapwide_focus_area, client):
+    """Test that map-wide focus area (no geometry) returns all exposure layers."""
+    # Create exposure layer type
+    exposure_layer_type = ExposureLayerType.objects.create(id=uuid.uuid4(), name="Rivers")
+
+    # Create two exposure layers in different locations
+    layer1_geom = GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
+    layer1 = ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Layer 1", geometry=layer1_geom, type=exposure_layer_type
+    )
+
+    layer2_geom = GEOSGeometry("POLYGON((10 10, 10 11, 11 11, 11 10, 10 10))")
+    layer2 = ExposureLayer.objects.create(
+        id=uuid.uuid4(), name="Layer 2", geometry=layer2_geom, type=exposure_layer_type
+    )
+
+    response = client.get(
+        f"/api/scenarios/{scenario.id}/exposure-layers/?focus_area_id={mapwide_focus_area.id}"
+    )
+    data = response.json()
+
+    assert response.status_code == http_success_code
+
+    # Should find both layers
+    layer1_data = find_exposure_layer_in_tree(data, layer1.id)
+    layer2_data = find_exposure_layer_in_tree(data, layer2.id)
+
+    assert layer1_data is not None
+    assert layer2_data is not None

--- a/backend/vista-python-api/src/api/views/scenario_exposure_layers.py
+++ b/backend/vista-python-api/src/api/views/scenario_exposure_layers.py
@@ -1,11 +1,12 @@
 """Views for scenario-scoped exposure layer operations."""
 
+from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from api.models import Scenario, VisibleExposureLayer
-from api.models.exposure_layer import ExposureLayerType
+from api.models import FocusArea, Scenario, VisibleExposureLayer
+from api.models.exposure_layer import ExposureLayer, ExposureLayerType
 from api.utils.auth import get_user_id_from_request
 
 
@@ -16,29 +17,46 @@ class ScenarioExposureLayersView(APIView):
         """List all exposure layer types with nested exposure layers.
 
         Each exposure layer includes isActive indicating visibility for the user.
+        Only exposure layers that intersect the focus area geometry are returned.
+        If focus area has no geometry (map-wide), all exposure layers are returned.
 
         Query params:
-            focus_area_id: Optional UUID. If provided, returns visibility status
-                for that specific focus area. If omitted, returns map-wide
-                (global) visibility status where focus_area is NULL.
+            focus_area_id: Required UUID. Returns visibility status for that
+                specific focus area.
         """
-        get_object_or_404(Scenario, id=scenario_id)
-
-        focus_area_id = request.query_params.get("focus_area_id")
+        scenario = get_object_or_404(Scenario, id=scenario_id)
         user_id = get_user_id_from_request(request)
+        focus_area_id = request.query_params.get("focus_area_id")
 
-        visible_query = VisibleExposureLayer.objects.filter(
-            scenario_id=scenario_id,
-            user_id=user_id,
+        if not focus_area_id:
+            return Response(
+                {"error": "focus_area_id query parameter is required"},
+                status=400,
+            )
+
+        focus_area = get_object_or_404(
+            FocusArea, id=focus_area_id, scenario=scenario, user_id=user_id
         )
 
-        if focus_area_id:
-            visible_query = visible_query.filter(focus_area_id=focus_area_id)
-        else:
-            visible_query = visible_query.filter(focus_area__isnull=True)
+        visible_exposure_layer_ids = set(
+            VisibleExposureLayer.objects.filter(focus_area=focus_area).values_list(
+                "exposure_layer_id", flat=True
+            )
+        )
 
-        visible_exposure_layer_ids = set(visible_query.values_list("exposure_layer_id", flat=True))
-        exposure_layer_types = ExposureLayerType.objects.prefetch_related("exposure_layers")
+        # Filter exposure layers by geometry intersection if focus area has geometry
+        if focus_area.geometry:
+            exposure_layers_filter = ExposureLayer.objects.filter(
+                geometry__intersects=focus_area.geometry
+            )
+        else:
+            # Map-wide focus area: return all exposure layers
+            exposure_layers_filter = ExposureLayer.objects.all()
+
+        exposure_layer_types = ExposureLayerType.objects.prefetch_related(
+            Prefetch("exposure_layers", queryset=exposure_layers_filter)
+        )
+
         result = [
             {
                 "id": str(exposure_layer_type.id),

--- a/backend/vista-python-api/src/api/views/visible_exposure_layers.py
+++ b/backend/vista-python-api/src/api/views/visible_exposure_layers.py
@@ -22,8 +22,7 @@ class VisibleExposureLayerView(APIView):
         When is_active is true, creates a VisibleExposureLayer record.
         When is_active is false, deletes the VisibleExposureLayer record.
 
-        If focus_area_id is provided, toggles visibility for that specific
-        focus area. Otherwise, toggles map-wide visibility.
+        focus_area_id is required and specifies which focus area scope to toggle.
         """
         scenario = get_object_or_404(Scenario, id=scenario_id, is_active=True)
         user_id = get_user_id_from_request(request)
@@ -32,28 +31,21 @@ class VisibleExposureLayerView(APIView):
         serializer.is_valid(raise_exception=True)
 
         exposure_layer_id = serializer.validated_data["exposure_layer_id"]
-        focus_area_id = serializer.validated_data.get("focus_area_id")
+        focus_area_id = serializer.validated_data["focus_area_id"]
         is_active = serializer.validated_data["is_active"]
 
         exposure_layer = get_object_or_404(ExposureLayer, id=exposure_layer_id)
-
-        focus_area = None
-        if focus_area_id:
-            focus_area = get_object_or_404(
-                FocusArea, id=focus_area_id, scenario=scenario, user_id=user_id
-            )
+        focus_area = get_object_or_404(
+            FocusArea, id=focus_area_id, scenario=scenario, user_id=user_id
+        )
 
         if is_active:
             VisibleExposureLayer.objects.get_or_create(
-                scenario=scenario,
-                user_id=user_id,
                 focus_area=focus_area,
                 exposure_layer=exposure_layer,
             )
         else:
             VisibleExposureLayer.objects.filter(
-                scenario=scenario,
-                user_id=user_id,
                 focus_area=focus_area,
                 exposure_layer=exposure_layer,
             ).delete()


### PR DESCRIPTION
Restricts the returned exposure layers to what is visible within the FocusArea provided as well.

## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Update exposure layers to work with the changes to FocusAreas now containing the Map-wide as a system area.

## Description

Also restricted the visible scenario exposure layers endpoint to filter what is returned based on if it intersects with the focus area or not.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Locally & unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
