### PR TITLE
feat(DPAV-1786): Add focus area selection and filtering to panels

### DIFF
--- a/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
+++ b/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
@@ -8,7 +8,7 @@ from django.contrib.gis.geos import GEOSGeometry, Point
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
-from api.models import AssetScoreFilter, FocusArea, ScenarioAsset, VisibleAsset
+from api.models import AssetScoreFilter, FocusArea, Scenario, ScenarioAsset, VisibleAsset
 from api.models.asset import Asset
 from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
 
@@ -166,6 +166,236 @@ def test_scenario_assets_no_visibility_returns_empty(scenario, assets_for_scenar
 
     assert response.status_code == http_success_code
     assert len(data) == 0
+
+
+# =============================================================================
+# Focus Area ID Query Parameter Tests
+# =============================================================================
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_returns_only_that_area(
+    scenario,
+    asset_types_for_scenario,
+    assets_for_scenario,
+    focus_area,
+    client,
+):
+    """Test that focus_area_id query param returns only assets for that focus area."""
+    rail_type = asset_types_for_scenario["rail"]
+
+    VisibleAsset.objects.create(
+        focus_area=focus_area,
+        asset_type=rail_type,
+    )
+
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={focus_area.id}")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    assert len(data) == 1
+    assert data[0]["name"] == assets_for_scenario["rail_inside"].name
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_ignores_other_focus_areas(  # noqa: PLR0913
+    scenario,
+    asset_types_for_scenario,
+    assets_for_scenario,
+    focus_area,
+    mapwide_focus_area,
+    client,
+):
+    """Test that focus_area_id param ignores other active focus areas."""
+    rail_type = asset_types_for_scenario["rail"]
+    hospital_type = asset_types_for_scenario["hospital"]
+
+    # Enable rail on the focus area we query
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=rail_type)
+    # Enable hospital on map-wide (should be ignored when querying specific focus area)
+    VisibleAsset.objects.create(focus_area=mapwide_focus_area, asset_type=hospital_type)
+
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={focus_area.id}")
+    data = response.json()
+
+    # Should only return rail inside focus area, not hospitals from map-wide
+    assert response.status_code == http_success_code
+    assert len(data) == 1
+    assert data[0]["name"] == assets_for_scenario["rail_inside"].name
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_invalid_focus_area_id_returns_404(scenario, client):
+    """Test that invalid focus_area_id returns 404."""
+    fake_id = uuid.uuid4()
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={fake_id}")
+    assert response.status_code == http_not_found
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_wrong_scenario_returns_404(
+    scenario,  # noqa: ARG001
+    focus_area,
+    client,
+):
+    """Test that focus_area_id for different scenario returns 404."""
+    # Create another scenario
+    other_scenario = Scenario.objects.create(
+        id=uuid.uuid4(),
+        name="Other Scenario",
+        is_active=True,
+    )
+
+    # Try to access focus area from wrong scenario
+    url = f"/api/scenarios/{other_scenario.id}/assets/?focus_area_id={focus_area.id}"
+    response = client.get(url)
+    assert response.status_code == http_not_found
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_wrong_user_returns_404(
+    scenario,
+    asset_types_for_scenario,
+    client,
+):
+    """Test that focus_area_id for different user returns 404."""
+    other_user_id = uuid.UUID("00000000-0000-0000-0000-000000000002")
+    rail_type = asset_types_for_scenario["rail"]
+
+    # Create focus area for another user
+    other_fa = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=other_user_id,
+        name="Other User FA",
+        geometry=GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"),
+        filter_mode="by_asset_type",
+        is_active=True,
+        is_system=False,
+    )
+    VisibleAsset.objects.create(focus_area=other_fa, asset_type=rail_type)
+
+    # Current user shouldn't be able to access it
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={other_fa.id}")
+    assert response.status_code == http_not_found
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_no_visibility_returns_empty(
+    scenario,
+    assets_for_scenario,  # noqa: ARG001
+    focus_area,
+    client,
+):
+    """Test that focus_area_id with no visible assets returns empty."""
+    # Don't add any VisibleAsset records
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={focus_area.id}")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    assert len(data) == 0
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_by_score_only_mode(
+    scenario,
+    score_test_types,
+    score_test_assets,
+    mock_user_id,
+    client,
+):
+    """Test focus_area_id with by_score_only mode returns scored assets."""
+    station_type = score_test_types["station"]
+    pylon_type = score_test_types["pylon"]
+
+    # Create ScenarioAsset records
+    ScenarioAsset.objects.create(scenario=scenario, asset_type=station_type, criticality_score=3)
+    ScenarioAsset.objects.create(scenario=scenario, asset_type=pylon_type, criticality_score=1)
+
+    # Create focus area with by_score_only mode
+    geom = GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
+    fa = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Score Only FA",
+        geometry=geom,
+        filter_mode="by_score_only",
+        is_active=True,
+        is_system=False,
+    )
+
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={fa.id}")
+    data = response.json()
+
+    # Both scored assets are inside geometry
+    assert response.status_code == http_success_code
+    assert len(data) == 2
+    names = [a["name"] for a in data]
+    assert score_test_assets["station"].name in names
+    assert score_test_assets["pylon"].name in names
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_focus_area_id_and_score_filter(
+    scenario,
+    score_test_types,
+    score_test_assets,
+    mock_user_id,
+    client,
+):
+    """Test focus_area_id with score filter applies the filter correctly."""
+    station_type = score_test_types["station"]
+    pylon_type = score_test_types["pylon"]
+
+    # Create ScenarioAsset records with different criticality scores
+    ScenarioAsset.objects.create(scenario=scenario, asset_type=station_type, criticality_score=3)
+    ScenarioAsset.objects.create(scenario=scenario, asset_type=pylon_type, criticality_score=1)
+
+    # Create focus area with by_score_only mode and global filter
+    geom = GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
+    fa = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Filtered Score FA",
+        geometry=geom,
+        filter_mode="by_score_only",
+        is_active=True,
+        is_system=False,
+    )
+    # Only allow criticality=3
+    AssetScoreFilter.objects.create(focus_area=fa, asset_type=None, criticality_values=[3])
+
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/?focus_area_id={fa.id}")
+    data = response.json()
+
+    # Only station (criticality=3) should be returned
+    assert response.status_code == http_success_code
+    assert len(data) == 1
+    assert data[0]["name"] == score_test_assets["station"].name
+
+
+@pytest.mark.django_db
+def test_scenario_assets_with_mapwide_focus_area_id(
+    scenario,
+    asset_types_for_scenario,
+    assets_for_scenario,
+    mapwide_focus_area,
+    client,
+):
+    """Test focus_area_id works with map-wide focus area (no geometry)."""
+    rail_type = asset_types_for_scenario["rail"]
+
+    VisibleAsset.objects.create(focus_area=mapwide_focus_area, asset_type=rail_type)
+
+    url = f"/api/scenarios/{scenario.id}/assets/?focus_area_id={mapwide_focus_area.id}"
+    response = client.get(url)
+    data = response.json()
+
+    # Should return all rail assets (no geometry filter)
+    assert response.status_code == http_success_code
+    assert len(data) == 2
+    names = [a["name"] for a in data]
+    assert assets_for_scenario["rail_inside"].name in names
+    assert assets_for_scenario["rail_outside"].name in names
 
 
 @pytest.mark.django_db

--- a/backend/vista-python-api/src/api/views/scenario_assets.py
+++ b/backend/vista-python-api/src/api/views/scenario_assets.py
@@ -39,6 +39,20 @@ class ScenarioAssetsView(APIView):
         """List assets visible in the scenario for the current user."""
         get_object_or_404(Scenario, id=scenario_id)
         user_id = get_user_id_from_request(request)
+        focus_area_id = request.query_params.get("focus_area_id", None)
+
+        if focus_area_id:
+            focus_area = get_object_or_404(
+                FocusArea.objects.prefetch_related("visible_assets", "asset_score_filters"),
+                id=focus_area_id,
+                scenario_id=scenario_id,
+                user_id=user_id,
+            )
+            combined_q = _build_focus_area_q(focus_area, scenario_id, user_id)
+            if not combined_q:
+                return Response([])
+            assets = Asset.objects.filter(combined_q).select_related("type").distinct()
+            return Response(ScenarioAssetSerializer(assets, many=True).data)
 
         focus_areas = FocusArea.objects.filter(
             scenario_id=scenario_id,

--- a/frontend/src/api/scenario-assets.ts
+++ b/frontend/src/api/scenario-assets.ts
@@ -17,11 +17,15 @@ type ScenarioAssetResponse = {
 
 export type FetchScenarioAssetsOptions = {
     scenarioId: string;
+    focusAreaId?: string | null;
     iconMap?: Map<string, string>;
 };
 
-export const fetchScenarioAssets = async ({ scenarioId, iconMap }: FetchScenarioAssetsOptions): Promise<Asset[]> => {
-    const url = `${config.services.apiBaseUrl}/scenarios/${scenarioId}/assets/`;
+export const fetchScenarioAssets = async ({ scenarioId, focusAreaId, iconMap }: FetchScenarioAssetsOptions): Promise<Asset[]> => {
+    let url = `${config.services.apiBaseUrl}/scenarios/${scenarioId}/assets/`;
+    if (focusAreaId) {
+        url += `?focus_area_id=${encodeURIComponent(focusAreaId)}`;
+    }
 
     const response = await fetch(url, {
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/components/map-v2/FocusAreaMask.test.tsx
+++ b/frontend/src/components/map-v2/FocusAreaMask.test.tsx
@@ -6,8 +6,8 @@ import type { Geometry } from 'geojson';
 import FocusAreaMask from './FocusAreaMask';
 
 vi.mock('react-map-gl/maplibre', () => ({
-    Source: ({ children, data }: { children: ReactNode; data: unknown }) => (
-        <div data-testid="source" data-geometry={JSON.stringify(data)}>
+    Source: ({ children, data, id }: { children: ReactNode; data: unknown; id: string }) => (
+        <div data-testid={`source-${id}`} data-geometry={JSON.stringify(data)}>
             {children}
         </div>
     ),
@@ -62,17 +62,24 @@ describe('FocusAreaMask', () => {
             expect(container.firstChild).toBeNull();
         });
 
-        it('renders Source and Layer when geometry is valid Polygon', () => {
+        it('renders mask Source and Layer when geometry is valid Polygon', () => {
             render(<FocusAreaMask geometry={mockPolygonGeometry} />);
-            expect(screen.getByTestId('source')).toBeInTheDocument();
+            expect(screen.getByTestId('source-focus-area-mask-source')).toBeInTheDocument();
             expect(screen.getByTestId('layer-focus-area-mask-layer')).toBeInTheDocument();
+        });
+
+        it('renders focus highlight Source and Layers when geometry is valid Polygon', () => {
+            render(<FocusAreaMask geometry={mockPolygonGeometry} />);
+            expect(screen.getByTestId('source-focus-area-highlight-source')).toBeInTheDocument();
+            expect(screen.getByTestId('layer-focus-area-highlight-fill-layer')).toBeInTheDocument();
+            expect(screen.getByTestId('layer-focus-area-highlight-line-layer')).toBeInTheDocument();
         });
     });
 
     describe('Mask Geometry', () => {
         it('creates a mask with world bounds and focus area as hole', () => {
             render(<FocusAreaMask geometry={mockPolygonGeometry} />);
-            const source = screen.getByTestId('source');
+            const source = screen.getByTestId('source-focus-area-mask-source');
             const data = JSON.parse(source.dataset.geometry || '{}');
 
             expect(data.type).toBe('Feature');
@@ -94,7 +101,7 @@ describe('FocusAreaMask', () => {
 
         it('reverses the focus area coordinates for the hole', () => {
             render(<FocusAreaMask geometry={mockPolygonGeometry} />);
-            const source = screen.getByTestId('source');
+            const source = screen.getByTestId('source-focus-area-mask-source');
             const data = JSON.parse(source.dataset.geometry || '{}');
 
             const originalCoords = mockPolygonGeometry.coordinates[0];
@@ -103,6 +110,17 @@ describe('FocusAreaMask', () => {
             // Hole should be reversed coordinates
             expect(hole[0]).toEqual(originalCoords[originalCoords.length - 1]);
             expect(hole[hole.length - 1]).toEqual(originalCoords[0]);
+        });
+    });
+
+    describe('Focus Highlight Geometry', () => {
+        it('creates a focus feature with the original geometry', () => {
+            render(<FocusAreaMask geometry={mockPolygonGeometry} />);
+            const source = screen.getByTestId('source-focus-area-highlight-source');
+            const data = JSON.parse(source.dataset.geometry || '{}');
+
+            expect(data.type).toBe('Feature');
+            expect(data.geometry).toEqual(mockPolygonGeometry);
         });
     });
 

--- a/frontend/src/components/map-v2/FocusAreaMask.tsx
+++ b/frontend/src/components/map-v2/FocusAreaMask.tsx
@@ -1,11 +1,20 @@
 import { useMemo } from 'react';
 import { Layer, Source } from 'react-map-gl/maplibre';
-import type { Geometry, Position } from 'geojson';
+import type { Geometry, Feature, Position } from 'geojson';
 
-const SOURCE_ID = 'focus-area-mask-source';
-const LAYER_ID = 'focus-area-mask-layer';
+const MASK_SOURCE_ID = 'focus-area-mask-source';
+const MASK_LAYER_ID = 'focus-area-mask-layer';
+const FOCUS_SOURCE_ID = 'focus-area-highlight-source';
+const FOCUS_FILL_LAYER_ID = 'focus-area-highlight-fill-layer';
+const FOCUS_LINE_LAYER_ID = 'focus-area-highlight-line-layer';
+
 const MASK_FILL_COLOUR = '#000000';
 const MASK_FILL_OPACITY = 0.4;
+const FOCUS_FILL_COLOUR = '#FF0C0C';
+const FOCUS_FILL_OPACITY = 0.2;
+const FOCUS_LINE_COLOUR = '#FF0C0C';
+const FOCUS_LINE_WIDTH = 2;
+const FOCUS_LINE_OPACITY = 0.6;
 
 const WORLD_BOUNDS: Position[] = [
     [-180, -90],
@@ -46,21 +55,62 @@ const FocusAreaMask = ({ geometry }: FocusAreaMaskProps) => {
         };
     }, [geometry]);
 
+    const focusFeature = useMemo((): Feature | null => {
+        if (geometry?.type !== 'Polygon') {
+            return null;
+        }
+
+        const outerRing = (geometry.coordinates as Position[][])[0];
+        if (!outerRing || outerRing.length === 0) {
+            return null;
+        }
+
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry,
+        };
+    }, [geometry]);
+
     if (!maskFeature) {
         return null;
     }
 
     return (
-        <Source id={SOURCE_ID} type="geojson" data={maskFeature}>
-            <Layer
-                id={LAYER_ID}
-                type="fill"
-                paint={{
-                    'fill-color': MASK_FILL_COLOUR,
-                    'fill-opacity': MASK_FILL_OPACITY,
-                }}
-            />
-        </Source>
+        <>
+            <Source id={MASK_SOURCE_ID} type="geojson" data={maskFeature}>
+                <Layer
+                    id={MASK_LAYER_ID}
+                    type="fill"
+                    paint={{
+                        'fill-color': MASK_FILL_COLOUR,
+                        'fill-opacity': MASK_FILL_OPACITY,
+                    }}
+                />
+            </Source>
+            {focusFeature && (
+                <Source id={FOCUS_SOURCE_ID} type="geojson" data={focusFeature}>
+                    <Layer
+                        id={FOCUS_FILL_LAYER_ID}
+                        type="fill"
+                        paint={{
+                            'fill-color': FOCUS_FILL_COLOUR,
+                            'fill-outline-color': FOCUS_LINE_COLOUR,
+                            'fill-opacity': FOCUS_FILL_OPACITY,
+                        }}
+                    />
+                    <Layer
+                        id={FOCUS_LINE_LAYER_ID}
+                        type="line"
+                        paint={{
+                            'line-color': FOCUS_LINE_COLOUR,
+                            'line-width': FOCUS_LINE_WIDTH,
+                            'line-opacity': FOCUS_LINE_OPACITY,
+                        }}
+                    />
+                </Source>
+            )}
+        </>
     );
 };
 

--- a/frontend/src/components/map-v2/FocusAreaOutline.test.tsx
+++ b/frontend/src/components/map-v2/FocusAreaOutline.test.tsx
@@ -1,0 +1,59 @@
+import { type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { Geometry } from 'geojson';
+
+import FocusAreaOutline from './FocusAreaOutline';
+
+vi.mock('react-map-gl/maplibre', () => ({
+    Source: ({ children, data }: { children: ReactNode; data: unknown }) => (
+        <div data-testid="source" data-geometry={JSON.stringify(data)}>
+            {children}
+        </div>
+    ),
+    Layer: ({ id }: { id: string }) => <div data-testid={`layer-${id}`} />,
+}));
+
+describe('FocusAreaOutline', () => {
+    const mockPolygon: Geometry = {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+                [0, 0],
+            ],
+        ],
+    };
+
+    it('renders nothing when geometry is null', () => {
+        const { container } = render(<FocusAreaOutline geometry={null} />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders Source and Layers for valid Polygon', () => {
+        render(<FocusAreaOutline geometry={mockPolygon} />);
+
+        expect(screen.getByTestId('source')).toBeInTheDocument();
+        expect(screen.getByTestId('layer-focus-area-outline-fill-layer')).toBeInTheDocument();
+        expect(screen.getByTestId('layer-focus-area-outline-line-layer')).toBeInTheDocument();
+    });
+
+    it('renders nothing for unsupported geometry types', () => {
+        const point: Geometry = { type: 'Point', coordinates: [0, 0] };
+        const { container } = render(<FocusAreaOutline geometry={point} />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('passes geometry to Source data', () => {
+        render(<FocusAreaOutline geometry={mockPolygon} />);
+
+        const source = screen.getByTestId('source');
+        const data = JSON.parse(source.dataset.geometry || '{}');
+
+        expect(data.type).toBe('Feature');
+        expect(data.geometry).toEqual(mockPolygon);
+    });
+});

--- a/frontend/src/components/map-v2/FocusAreaOutline.tsx
+++ b/frontend/src/components/map-v2/FocusAreaOutline.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { Layer, Source } from 'react-map-gl/maplibre';
+import type { Geometry, Feature, Position } from 'geojson';
+
+const SOURCE_ID = 'focus-area-outline-source';
+const FILL_LAYER_ID = 'focus-area-outline-fill-layer';
+const LINE_LAYER_ID = 'focus-area-outline-line-layer';
+
+type FocusAreaOutlineProps = {
+    readonly geometry: Geometry | null;
+    readonly fillColor?: string;
+    readonly fillOpacity?: number;
+    readonly lineColor?: string;
+    readonly lineWidth?: number;
+};
+
+const FocusAreaOutline = ({ geometry, fillColor = 'transparent', fillOpacity = 0, lineColor = '#666666', lineWidth = 2 }: FocusAreaOutlineProps) => {
+    const feature = useMemo((): Feature | null => {
+        if (!geometry || (geometry.type !== 'Polygon' && geometry.type !== 'MultiPolygon')) {
+            return null;
+        }
+
+        // For Polygon, check it has valid coordinates
+        if (geometry.type === 'Polygon') {
+            const outerRing = (geometry.coordinates as Position[][])[0];
+            if (!outerRing || outerRing.length === 0) {
+                return null;
+            }
+        }
+
+        return {
+            type: 'Feature',
+            properties: {},
+            geometry,
+        };
+    }, [geometry]);
+
+    if (!feature) {
+        return null;
+    }
+
+    return (
+        <Source id={SOURCE_ID} type="geojson" data={feature}>
+            <Layer
+                id={FILL_LAYER_ID}
+                type="fill"
+                paint={{
+                    'fill-color': fillColor,
+                    'fill-opacity': fillOpacity,
+                }}
+            />
+            <Layer
+                id={LINE_LAYER_ID}
+                type="line"
+                paint={{
+                    'line-color': lineColor,
+                    'line-width': lineWidth,
+                    'line-dasharray': [2, 2],
+                }}
+            />
+        </Source>
+    );
+};
+
+export default FocusAreaOutline;

--- a/frontend/src/components/map-v2/MapPanels.tsx
+++ b/frontend/src/components/map-v2/MapPanels.tsx
@@ -146,7 +146,16 @@ const MapPanels = ({
                     />
                 );
             case 'focus-area':
-                return <FocusAreaView onClose={handleClosePanel} scenarioId={scenarioId} isDrawing={isDrawing} onStartDrawing={onStartDrawing} />;
+                return (
+                    <FocusAreaView
+                        onClose={handleClosePanel}
+                        scenarioId={scenarioId}
+                        isDrawing={isDrawing}
+                        onStartDrawing={onStartDrawing}
+                        selectedFocusAreaId={selectedFocusAreaId}
+                        onFocusAreaSelect={onFocusAreaSelect}
+                    />
+                );
             case 'asset-details':
                 if (!onBackFromAssetDetails) {
                     return null;

--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -8,7 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './mapbox-draw-maplibre.css';
 
-import { bbox } from '@turf/turf';
+import { bbox, booleanPointInPolygon, point } from '@turf/turf';
 import { DEFAULT_VIEW_STATE, DEFAULT_MAP_STYLE, MAP_STYLES, MAP_VIEW_BOUNDS, type MapStyleKey } from './constants';
 import MapControls from './MapControls';
 import MapPanels from './MapPanels';
@@ -16,6 +16,7 @@ import AssetLayers from './AssetLayers';
 import ExposureLayers from './ExposureLayers';
 import UtilitiesLayers from './UtilitiesLayers';
 import FocusAreaMask from './FocusAreaMask';
+import FocusAreaOutline from './FocusAreaOutline';
 import RadiusDialog from './RadiusDialog';
 import useMapboxDraw from './hooks/useMapboxDraw';
 import useFocusAreas from './hooks/useFocusAreas';
@@ -50,14 +51,18 @@ const MapView = () => {
     const scenarioId = activeScenario?.id;
     const iconMap = useAssetTypeIcons();
 
+    const isInFocusAreaPanel = activePanelView === 'focus-area';
+    const [selectedFocusAreaId, setSelectedFocusAreaId] = useState<string | null>(null);
+
     const { focusAreas, isDrawing, drawingMode, startDrawing, createCircleAtPoint } = useFocusAreas({
         scenarioId,
         mapRef,
         drawRef,
         mapReady,
+        isEditable: isInFocusAreaPanel,
+        selectedFocusAreaId,
+        onFocusAreaSelect: setSelectedFocusAreaId,
     });
-
-    const [selectedFocusAreaId, setSelectedFocusAreaId] = useState<string | null>(null);
     const handleFocusAreaSelect = useCallback(
         (focusAreaId: string | null) => {
             setSelectedFocusAreaId(focusAreaId);
@@ -91,6 +96,16 @@ const MapView = () => {
         [focusAreas, mapReady],
     );
 
+    // Auto-select map-wide focus area when focusAreas loads and nothing is selected
+    useEffect(() => {
+        if (focusAreas && !selectedFocusAreaId) {
+            const mapWideFocusArea = focusAreas.find((fa) => fa.isSystem);
+            if (mapWideFocusArea) {
+                setSelectedFocusAreaId(mapWideFocusArea.id);
+            }
+        }
+    }, [focusAreas, selectedFocusAreaId]);
+
     const mapStyle = useMemo(() => MAP_STYLES[mapStyleKey], [mapStyleKey]);
 
     const { data: assetCategories } = useQuery({
@@ -117,12 +132,12 @@ const MapView = () => {
         }
     }, [roadRouteStart, roadRouteEnd, roadRouteVehicle, isRoadRouteEnabled, getRoadRoute]);
 
+    const shouldFilterByFocusArea = activePanelView === 'assets' || activePanelView === 'exposure';
     const { assets } = useScenarioAssets({
         scenarioId,
+        focusAreaId: shouldFilterByFocusArea ? selectedFocusAreaId : undefined,
         iconMap,
     });
-
-    const isInFocusAreaPanel = activePanelView === 'focus-area';
 
     // Get IDs of all active focus areas (including system/map-wide)
     const activeFocusAreaIds = useMemo(() => {
@@ -131,7 +146,6 @@ const MapView = () => {
         }
         return focusAreas.filter((fa) => fa.isActive).map((fa) => fa.id);
     }, [focusAreas]);
-
 
     usePreloadAssetIcons(assets);
 
@@ -246,6 +260,46 @@ const MapView = () => {
         };
     }, [mapReady, drawingMode]);
 
+    // Handle clicks outside inactive focus areas to deselect them
+    useEffect(() => {
+        if (!mapReady || !isInFocusAreaPanel || !selectedFocusAreaId) {
+            return;
+        }
+
+        const selectedFocusArea = focusAreas?.find((fa) => fa.id === selectedFocusAreaId);
+        // Only handle clicks for inactive, non-system focus areas (active ones are handled by MapboxDraw)
+        if (!selectedFocusArea || selectedFocusArea.isActive || selectedFocusArea.isSystem) {
+            return;
+        }
+
+        const map = mapRef.current?.getMap();
+        if (!map) {
+            return;
+        }
+
+        const handleClickOutside = (e: MapMouseEvent) => {
+            const clickPoint = point([e.lngLat.lng, e.lngLat.lat]);
+            const geometry = selectedFocusArea.geometry;
+
+            if (geometry && (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon')) {
+                const isInside = booleanPointInPolygon(clickPoint, geometry);
+                if (!isInside) {
+                    // Click was outside - revert to map-wide
+                    const mapWideFocusArea = focusAreas?.find((fa) => fa.isSystem);
+                    if (mapWideFocusArea) {
+                        setSelectedFocusAreaId(mapWideFocusArea.id);
+                    }
+                }
+            }
+        };
+
+        map.on('click', handleClickOutside);
+
+        return () => {
+            map.off('click', handleClickOutside);
+        };
+    }, [mapReady, isInFocusAreaPanel, selectedFocusAreaId, focusAreas]);
+
     const transformRequest = useCallback((url: string) => {
         let transformedUrl = url;
         const headers: Record<string, string> = {};
@@ -344,12 +398,12 @@ const MapView = () => {
                 roadRouteData={
                     roadRouteQueryData?.roadRoute
                         ? {
-                            routeGeojson: {
-                                features: roadRouteQueryData.roadRoute.routeGeojson.features.map((f) => ({
-                                    properties: f.properties || {},
-                                })),
-                            },
-                        }
+                              routeGeojson: {
+                                  features: roadRouteQueryData.roadRoute.routeGeojson.features.map((f) => ({
+                                      properties: f.properties || {},
+                                  })),
+                              },
+                          }
                         : undefined
                 }
                 onRoadRouteVehicleChange={setRoadRouteVehicle}
@@ -388,6 +442,16 @@ const MapView = () => {
                             {!isInFocusAreaPanel && selectedFocusAreaId && (
                                 <FocusAreaMask geometry={focusAreas?.find((fa) => fa.id === selectedFocusAreaId)?.geometry ?? null} />
                             )}
+                            {isInFocusAreaPanel &&
+                                selectedFocusAreaId &&
+                                (() => {
+                                    const selectedFocusArea = focusAreas?.find((fa) => fa.id === selectedFocusAreaId);
+                                    // Show gray outline for inactive focus areas in the Focus Area panel
+                                    if (selectedFocusArea && !selectedFocusArea.isActive && selectedFocusArea.geometry) {
+                                        return <FocusAreaOutline geometry={selectedFocusArea.geometry} lineColor="#888888" />;
+                                    }
+                                    return null;
+                                })()}
                             <AssetLayers
                                 assets={assets}
                                 selectedElements={selectedElement ? [selectedElement] : []}

--- a/frontend/src/components/map-v2/hooks/useAssetFilterMutations.test.tsx
+++ b/frontend/src/components/map-v2/hooks/useAssetFilterMutations.test.tsx
@@ -37,6 +37,14 @@ function createQueryClient() {
     });
 }
 
+function createDeferredPromise<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+        resolve = r;
+    });
+    return { promise, resolve };
+}
+
 function createWrapper(queryClient: QueryClient) {
     return function Wrapper({ children }: { children: ReactNode }) {
         return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
@@ -486,13 +494,8 @@ describe('useAssetFilterMutations', () => {
         });
 
         it('is true while visibility mutation is pending', async () => {
-            let resolveVisibility: () => void;
-            mockedToggleAssetTypeVisibility.mockImplementation(
-                () =>
-                    new Promise((resolve) => {
-                        resolveVisibility = () => resolve({ assetTypeId: 'asset-1', focusAreaId: 'fa-1', isActive: true });
-                    }),
-            );
+            const deferred = createDeferredPromise<{ assetTypeId: string; focusAreaId: string; isActive: boolean }>();
+            mockedToggleAssetTypeVisibility.mockReturnValue(deferred.promise);
 
             const { result } = renderHook(
                 () =>
@@ -513,7 +516,7 @@ describe('useAssetFilterMutations', () => {
             });
 
             act(() => {
-                resolveVisibility!();
+                deferred.resolve({ assetTypeId: 'asset-1', focusAreaId: 'fa-1', isActive: true });
             });
 
             await waitFor(() => {
@@ -522,13 +525,8 @@ describe('useAssetFilterMutations', () => {
         });
 
         it('is true while clearAll mutation is pending', async () => {
-            let resolveClearAll: () => void;
-            mockedClearAllAssetTypeVisibility.mockImplementation(
-                () =>
-                    new Promise((resolve) => {
-                        resolveClearAll = () => resolve(undefined);
-                    }),
-            );
+            const deferred = createDeferredPromise<void>();
+            mockedClearAllAssetTypeVisibility.mockReturnValue(deferred.promise);
 
             const { result } = renderHook(
                 () =>
@@ -549,7 +547,7 @@ describe('useAssetFilterMutations', () => {
             });
 
             act(() => {
-                resolveClearAll!();
+                deferred.resolve();
             });
 
             await waitFor(() => {
@@ -574,21 +572,16 @@ describe('useAssetFilterMutations', () => {
         });
 
         it('is true while filter mode mutation is pending', async () => {
-            let resolveFilterMode: () => void;
-            mockedUpdateFocusArea.mockImplementation(
-                () =>
-                    new Promise((resolve) => {
-                        resolveFilterMode = () =>
-                            resolve({
-                                id: 'fa-1',
-                                name: 'Focus Area',
-                                geometry: null,
-                                filterMode: 'by_score_only',
-                                isActive: true,
-                                isSystem: false,
-                            });
-                    }),
-            );
+            const mockResponse = {
+                id: 'fa-1',
+                name: 'Focus Area',
+                geometry: null,
+                filterMode: 'by_score_only' as const,
+                isActive: true,
+                isSystem: false,
+            };
+            const deferred = createDeferredPromise<typeof mockResponse>();
+            mockedUpdateFocusArea.mockReturnValue(deferred.promise);
 
             const { result } = renderHook(
                 () =>
@@ -609,7 +602,7 @@ describe('useAssetFilterMutations', () => {
             });
 
             act(() => {
-                resolveFilterMode!();
+                deferred.resolve(mockResponse);
             });
 
             await waitFor(() => {

--- a/frontend/src/components/map-v2/hooks/useFocusAreas.test.tsx
+++ b/frontend/src/components/map-v2/hooks/useFocusAreas.test.tsx
@@ -64,6 +64,7 @@ type MockMapboxDraw = {
     delete: ReturnType<typeof vi.fn>;
     changeMode: ReturnType<typeof vi.fn>;
     getMode: ReturnType<typeof vi.fn>;
+    getSelectedIds: ReturnType<typeof vi.fn>;
 };
 
 type MockMap = {
@@ -78,6 +79,7 @@ function createMockDrawRef(): { current: MockMapboxDraw } {
             delete: vi.fn(),
             changeMode: vi.fn(),
             getMode: vi.fn().mockReturnValue('simple_select'),
+            getSelectedIds: vi.fn().mockReturnValue([]),
         },
     };
 }
@@ -915,6 +917,316 @@ describe('useFocusAreas', () => {
             });
 
             expect(result.current.drawingMode).toBe(null);
+        });
+    });
+
+    describe('selectedFocusAreaId sync to MapboxDraw', () => {
+        it('selects the focus area in draw when selectedFocusAreaId is provided and area is loaded', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            mockDrawRef.current.getSelectedIds.mockReturnValue([]);
+
+            const { rerender } = renderHook(
+                ({ selectedFocusAreaId }) =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        isEditable: true,
+                        selectedFocusAreaId,
+                    }),
+                { wrapper: createWrapper(queryClient), initialProps: { selectedFocusAreaId: null as string | null } },
+            );
+
+            // Wait for focus area to be loaded into draw
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalled();
+            });
+
+            // Clear the changeMode calls from initialization
+            mockDrawRef.current.changeMode.mockClear();
+
+            // Now set the selectedFocusAreaId
+            rerender({ selectedFocusAreaId: 'fa-1' });
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.changeMode).toHaveBeenCalledWith('simple_select', { featureIds: ['fa-1'] });
+            });
+        });
+
+        it('does not select if focus area is not loaded in draw', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: false })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        isEditable: true,
+                        selectedFocusAreaId: 'fa-1',
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            expect(mockDrawRef.current.changeMode).not.toHaveBeenCalledWith('simple_select', expect.objectContaining({ featureIds: ['fa-1'] }));
+        });
+
+        it('does not change selection if already selected', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            mockDrawRef.current.getSelectedIds.mockReturnValue(['fa-1']);
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        isEditable: true,
+                        selectedFocusAreaId: 'fa-1',
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalled();
+            });
+
+            // Wait a bit to ensure no additional changeMode calls are made
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 50);
+            });
+
+            // changeMode should only have been called for draw modes, not for selection
+            expect(mockDrawRef.current.changeMode).not.toHaveBeenCalledWith('simple_select', expect.objectContaining({ featureIds: ['fa-1'] }));
+        });
+    });
+
+    describe('draw.selectionchange handler', () => {
+        it('calls onFocusAreaSelect when a focus area is selected in draw', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            const onFocusAreaSelect = vi.fn();
+            let selectionChangeHandler: (event: { features: Feature[] }) => void;
+
+            mockMap.on.mockImplementation((event: string, handler: any) => {
+                if (event === 'draw.selectionchange') {
+                    selectionChangeHandler = handler;
+                }
+            });
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        onFocusAreaSelect,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalled();
+            });
+
+            const selectedFeature: Feature = {
+                type: 'Feature',
+                id: 'fa-1',
+                properties: {},
+                geometry: mockGeometry,
+            };
+
+            act(() => {
+                selectionChangeHandler({ features: [selectedFeature] });
+            });
+
+            expect(onFocusAreaSelect).toHaveBeenCalledWith('fa-1');
+        });
+
+        it('reverts to map-wide focus area when selection is cleared', async () => {
+            const mapWideFocusArea = createMockFocusArea({ id: 'map-wide', isActive: true, isSystem: true, geometry: null });
+            const userFocusArea = createMockFocusArea({ id: 'fa-1', isActive: true });
+            mockedFetchFocusAreas.mockResolvedValue([mapWideFocusArea, userFocusArea]);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            const onFocusAreaSelect = vi.fn();
+            let selectionChangeHandler: (event: { features: Feature[] }) => void;
+
+            mockMap.on.mockImplementation((event: string, handler: any) => {
+                if (event === 'draw.selectionchange') {
+                    selectionChangeHandler = handler;
+                }
+            });
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        onFocusAreaSelect,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalled();
+            });
+
+            act(() => {
+                selectionChangeHandler({ features: [] });
+            });
+
+            expect(onFocusAreaSelect).toHaveBeenCalledWith('map-wide');
+        });
+
+        it('does not call onFocusAreaSelect if callback is not provided', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+            let selectionChangeHandler: (event: { features: Feature[] }) => void;
+
+            mockMap.on.mockImplementation((event: string, handler: any) => {
+                if (event === 'draw.selectionchange') {
+                    selectionChangeHandler = handler;
+                }
+            });
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalled();
+            });
+
+            const selectedFeature: Feature = {
+                type: 'Feature',
+                id: 'fa-1',
+                properties: {},
+                geometry: mockGeometry,
+            };
+
+            // Should not throw
+            act(() => {
+                selectionChangeHandler({ features: [selectedFeature] });
+            });
+        });
+
+        it('registers draw.selectionchange event handler', async () => {
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockMap.on).toHaveBeenCalledWith('draw.selectionchange', expect.any(Function));
+            });
+        });
+    });
+
+    describe('isEditable behavior', () => {
+        it('clears all drawn features when isEditable becomes false', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true }), createMockFocusArea({ id: 'fa-2', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            const { rerender } = renderHook(
+                ({ isEditable }) =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        isEditable,
+                    }),
+                {
+                    wrapper: createWrapper(queryClient),
+                    initialProps: { isEditable: true },
+                },
+            );
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.add).toHaveBeenCalledTimes(2);
+            });
+
+            rerender({ isEditable: false });
+
+            await waitFor(() => {
+                expect(mockDrawRef.current.delete).toHaveBeenCalledWith('fa-1');
+                expect(mockDrawRef.current.delete).toHaveBeenCalledWith('fa-2');
+            });
+        });
+
+        it('does not add focus areas to draw when isEditable is false', async () => {
+            const mockFocusAreas = [createMockFocusArea({ id: 'fa-1', isActive: true })];
+            mockedFetchFocusAreas.mockResolvedValue(mockFocusAreas);
+
+            const mockMap = createMockMap();
+            const mockDrawRef = createMockDrawRef();
+
+            renderHook(
+                () =>
+                    useFocusAreas({
+                        scenarioId: 'scenario-123',
+                        mapRef: createMockMapRef(mockMap) as any,
+                        drawRef: mockDrawRef as any,
+                        mapReady: true,
+                        isEditable: false,
+                    }),
+                { wrapper: createWrapper(queryClient) },
+            );
+
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            expect(mockDrawRef.current.add).not.toHaveBeenCalled();
         });
     });
 });

--- a/frontend/src/components/map-v2/hooks/useFocusAreas.ts
+++ b/frontend/src/components/map-v2/hooks/useFocusAreas.ts
@@ -12,9 +12,12 @@ type UseFocusAreasOptions = {
     mapRef: RefObject<MapRef | null>;
     drawRef: RefObject<MapboxDraw | null>;
     mapReady: boolean;
+    isEditable?: boolean;
+    selectedFocusAreaId?: string | null;
+    onFocusAreaSelect?: (focusAreaId: string | null) => void;
 };
 
-const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasOptions) => {
+const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady, isEditable = true, selectedFocusAreaId, onFocusAreaSelect }: UseFocusAreasOptions) => {
     const loadedFocusAreaIdsRef = useRef<Set<string>>(new Set());
     const focusAreasRef = useRef<FocusArea[] | undefined>(undefined);
     const [drawingMode, setDrawingMode] = useState<'circle' | 'polygon' | null>(null);
@@ -41,27 +44,42 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
     // Store mutation functions in refs for stable references in event handlers
     const createMutateRef = useRef(createFocusAreaMutate);
     const updateMutateRef = useRef(updateFocusAreaMutate);
+    const onFocusAreaSelectRef = useRef(onFocusAreaSelect);
     useEffect(() => {
         createMutateRef.current = createFocusAreaMutate;
         updateMutateRef.current = updateFocusAreaMutate;
-    }, [createFocusAreaMutate, updateFocusAreaMutate]);
+        onFocusAreaSelectRef.current = onFocusAreaSelect;
+    }, [createFocusAreaMutate, updateFocusAreaMutate, onFocusAreaSelect]);
 
-    // Sync active focus areas to MapboxDraw
+    // Sync active focus areas to MapboxDraw (only when editable)
     useEffect(() => {
-        if (!mapReady || !drawRef.current || !focusAreas) {
+        if (!mapReady || !drawRef.current) {
             return;
         }
 
         const draw = drawRef.current;
+
+        // If not editable, clear all drawn features
+        if (!isEditable) {
+            loadedFocusAreaIdsRef.current.forEach((id) => {
+                try {
+                    draw.delete(id);
+                } catch {
+                    // Feature may already be deleted
+                }
+            });
+            loadedFocusAreaIdsRef.current.clear();
+            return;
+        }
+
+        if (!focusAreas) {
+            return;
+        }
+
         const activeFocusAreaIds = new Set<string>();
 
         for (const focusArea of focusAreas) {
-            // Skip system focus areas (map-wide) - they have no geometry
-            if (focusArea.isSystem || !focusArea.geometry) {
-                continue;
-            }
-
-            if (!focusArea.isActive) {
+            if (!focusArea.isActive || !focusArea.geometry) {
                 continue;
             }
 
@@ -97,7 +115,24 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
             }
             loadedFocusAreaIdsRef.current.delete(id);
         }
-    }, [mapReady, drawRef, focusAreas]);
+    }, [mapReady, drawRef, focusAreas, isEditable]);
+
+    // Sync selectedFocusAreaId to MapboxDraw selection (when selected from side panel)
+    useEffect(() => {
+        if (!mapReady || !drawRef.current || !selectedFocusAreaId) {
+            return;
+        }
+
+        // Only select if it's loaded in draw (i.e., it's an active focus area with isEditable=true)
+        if (loadedFocusAreaIdsRef.current.has(selectedFocusAreaId)) {
+            const draw = drawRef.current;
+            const currentSelected = draw.getSelectedIds();
+
+            if (currentSelected.length !== 1 || currentSelected[0] !== selectedFocusAreaId) {
+                draw.changeMode('simple_select', { featureIds: [selectedFocusAreaId] });
+            }
+        }
+    }, [mapReady, drawRef, selectedFocusAreaId]);
 
     // Handle draw events
     useEffect(() => {
@@ -154,14 +189,37 @@ const useFocusAreas = ({ scenarioId, mapRef, drawRef, mapReady }: UseFocusAreasO
             }
         };
 
+        const handleSelectionChange = (event: { features: Feature[] }) => {
+            if (!onFocusAreaSelectRef.current) {
+                return;
+            }
+
+            if (event.features.length > 0) {
+                const selectedFeature = event.features[0];
+                const focusAreaId = selectedFeature.id;
+                if (focusAreaId && loadedFocusAreaIdsRef.current.has(String(focusAreaId))) {
+                    onFocusAreaSelectRef.current(String(focusAreaId));
+                }
+            } else {
+                // Nothing selected - revert to map-wide
+                const currentFocusAreas = focusAreasRef.current;
+                const mapWideFocusArea = currentFocusAreas?.find((fa) => fa.isSystem);
+                if (mapWideFocusArea) {
+                    onFocusAreaSelectRef.current(mapWideFocusArea.id);
+                }
+            }
+        };
+
         map.on('draw.create', handleDrawCreate);
         map.on('draw.modechange', handleModeChange);
         map.on('draw.update', handleDrawUpdate);
+        map.on('draw.selectionchange', handleSelectionChange);
 
         return () => {
             map.off('draw.create', handleDrawCreate);
             map.off('draw.modechange', handleModeChange);
             map.off('draw.update', handleDrawUpdate);
+            map.off('draw.selectionchange', handleSelectionChange);
         };
     }, [mapReady, mapRef, drawRef, scenarioId]);
 

--- a/frontend/src/components/map-v2/hooks/useScoreFilterState.ts
+++ b/frontend/src/components/map-v2/hooks/useScoreFilterState.ts
@@ -39,6 +39,7 @@ export type UseScoreFilterStateReturn = {
     buildFilterPayload: () => ScoreFilterValues;
     resetToDefaults: () => void;
     isDefaultFilter: () => boolean;
+    isValidRange: () => boolean;
 };
 
 export function useScoreFilterState({ initialValues }: UseScoreFilterStateOptions = {}): UseScoreFilterStateReturn {
@@ -51,7 +52,7 @@ export function useScoreFilterState({ initialValues }: UseScoreFilterStateOption
     const handleCheckboxChange = useCallback((setter: Dispatch<SetStateAction<number[]>>, value: number, checked: boolean) => {
         setter((prev) => {
             if (checked) {
-                return [...prev, value].sort();
+                return [...prev, value].sort((a, b) => a - b);
             }
             return prev.filter((v) => v !== value);
         });
@@ -87,6 +88,12 @@ export function useScoreFilterState({ initialValues }: UseScoreFilterStateOption
         setDependencyMax(DEFAULT_DEPENDENCY_MAX);
     }, []);
 
+    const isValidRange = useCallback(() => {
+        const min = Number.parseFloat(dependencyMin);
+        const max = Number.parseFloat(dependencyMax);
+        return !Number.isNaN(min) && !Number.isNaN(max) && min <= max;
+    }, [dependencyMin, dependencyMax]);
+
     return {
         criticalityValues,
         setCriticalityValues,
@@ -102,6 +109,7 @@ export function useScoreFilterState({ initialValues }: UseScoreFilterStateOption
         buildFilterPayload,
         resetToDefaults,
         isDefaultFilter: checkIsDefaultFilter,
+        isValidRange,
     };
 }
 

--- a/frontend/src/components/map-v2/panels/AssetsView.test.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.test.tsx
@@ -43,6 +43,7 @@ describe('AssetsView', () => {
     const defaultProps = {
         onClose: vi.fn(),
         scenarioId: 'test-scenario-id',
+        selectedFocusAreaId: 'map-wide-1',
     };
 
     let queryClient: QueryClient;
@@ -196,7 +197,7 @@ describe('AssetsView', () => {
             setupMocks();
             renderWithProviders(<AssetsView {...defaultProps} />);
             await waitFor(() => {
-                expect(screen.getByLabelText('Select visible focus area')).toBeInTheDocument();
+                expect(screen.getByLabelText('Select focus area')).toBeInTheDocument();
             });
         });
 
@@ -273,10 +274,10 @@ describe('AssetsView', () => {
             });
 
             await waitFor(() => {
-                expect(screen.getByLabelText('Select visible focus area')).toBeInTheDocument();
+                expect(screen.getByLabelText('Select focus area')).toBeInTheDocument();
             });
 
-            const selectElement = screen.getByLabelText('Select visible focus area');
+            const selectElement = screen.getByLabelText('Select focus area');
             fireEvent.mouseDown(selectElement);
 
             await waitFor(
@@ -300,10 +301,10 @@ describe('AssetsView', () => {
             });
 
             await waitFor(() => {
-                expect(screen.getByLabelText('Select visible focus area')).toBeInTheDocument();
+                expect(screen.getByLabelText('Select focus area')).toBeInTheDocument();
             });
 
-            const selectElement = screen.getByLabelText('Select visible focus area');
+            const selectElement = screen.getByLabelText('Select focus area');
             fireEvent.mouseDown(selectElement);
 
             await waitFor(
@@ -681,20 +682,9 @@ describe('AssetsView', () => {
     });
 
     describe('Filter Mode', () => {
-        it('disables filter mode select when no active scope', async () => {
-            setupMocks({
-                focusAreas: [
-                    {
-                        id: 'map-wide-1',
-                        name: 'Map-wide',
-                        geometry: null,
-                        filterMode: 'by_asset_type',
-                        isActive: false,
-                        isSystem: true,
-                    },
-                ],
-            });
-            renderWithProviders(<AssetsView {...defaultProps} />);
+        it('disables filter mode select when no focus area is selected', async () => {
+            setupMocks();
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId={null} />);
 
             await waitFor(() => {
                 const filterModeSelect = screen.getByLabelText('Select filter mode');
@@ -705,23 +695,12 @@ describe('AssetsView', () => {
             expect(filterModeSelect).toHaveClass('Mui-disabled');
         });
 
-        it('shows message when no active scope', async () => {
-            setupMocks({
-                focusAreas: [
-                    {
-                        id: 'map-wide-1',
-                        name: 'Map-wide',
-                        geometry: null,
-                        filterMode: 'by_asset_type',
-                        isActive: false,
-                        isSystem: true,
-                    },
-                ],
-            });
-            renderWithProviders(<AssetsView {...defaultProps} />);
+        it('shows message when no focus area is selected', async () => {
+            setupMocks();
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId={null} />);
 
             await waitFor(() => {
-                expect(screen.getByText('Enable a focus area or map-wide visibility to configure asset filters')).toBeInTheDocument();
+                expect(screen.getByText('Select a focus area to configure asset filters')).toBeInTheDocument();
             });
         });
 
@@ -738,44 +717,15 @@ describe('AssetsView', () => {
                     },
                 ],
             });
-            renderWithProviders(<AssetsView {...defaultProps} />);
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId="map-wide-1" />);
 
-            await waitFor(() => {
-                expect(screen.getByText('Assets')).toBeInTheDocument();
-            });
-
-            expect(screen.queryByPlaceholderText('Search for an asset')).not.toBeInTheDocument();
-        });
-    });
-
-    describe('Focus Area Edge Cases', () => {
-        it('auto-selects first active focus area when current is inactive', async () => {
-            const onFocusAreaSelect = vi.fn();
-            setupMocks({
-                focusAreas: [
-                    {
-                        id: 'inactive-1',
-                        name: 'Inactive Area',
-                        geometry: null,
-                        filterMode: 'by_asset_type',
-                        isActive: false,
-                        isSystem: false,
-                    },
-                    {
-                        id: 'active-1',
-                        name: 'Active Area',
-                        geometry: { type: 'Point', coordinates: [0, 0] },
-                        filterMode: 'by_asset_type',
-                        isActive: true,
-                        isSystem: false,
-                    },
-                ],
-            });
-            renderWithProviders(<AssetsView {...defaultProps} onFocusAreaSelect={onFocusAreaSelect} />);
-
-            await waitFor(() => {
-                expect(onFocusAreaSelect).toHaveBeenCalledWith('active-1');
-            });
+            // Wait for focus areas to load and filter mode to be applied
+            await waitFor(
+                () => {
+                    expect(screen.queryByPlaceholderText('Search for an asset')).not.toBeInTheDocument();
+                },
+                { timeout: 2000 },
+            );
         });
     });
 

--- a/frontend/src/components/map-v2/panels/AssetsView.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import {
     Alert,
     Box,
@@ -25,6 +25,7 @@ import useAssetFilterMutations from '../hooks/useAssetFilterMutations';
 import { isDefaultFilter } from '../hooks/useScoreFilterState';
 import { GlobalScoreFilter } from './GlobalScoreFilter';
 import { ScoreFilterPopup } from './ScoreFilterPopup';
+import FocusAreaSelector from './FocusAreaSelector';
 import { SearchTextField } from '@/components/SearchTextField';
 import IconToggle from '@/components/IconToggle';
 import { useDataSources } from '@/hooks/useDataSources';
@@ -41,6 +42,78 @@ type AssetsViewProps = {
 };
 
 type FilterMode = FocusArea['filterMode'];
+
+type SubCategoryItemProps = {
+    readonly subCategory: ScenarioSubCategory;
+    readonly isExpanded: boolean;
+    readonly onToggleExpand: (id: string) => void;
+    readonly onToggleVisibility: (assetTypeId: string, isActive: boolean) => void;
+    readonly onOpenScoreFilter: (assetType: ScenarioAssetType) => void;
+    readonly getScoreFilter: (assetTypeId: string) => AssetScoreFilter | undefined;
+    readonly isMutating: boolean;
+    readonly dataSourceMap: Map<string, DataSource>;
+};
+
+function SubCategoryItem({
+    subCategory,
+    isExpanded,
+    onToggleExpand,
+    onToggleVisibility,
+    onOpenScoreFilter,
+    getScoreFilter,
+    isMutating,
+    dataSourceMap,
+}: SubCategoryItemProps) {
+    const activeCount = subCategory.assetTypes.filter((at) => at.isActive).length;
+
+    const handleClick = () => onToggleExpand(subCategory.id);
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggleExpand(subCategory.id);
+        }
+    };
+
+    return (
+        <Box>
+            <Box
+                onClick={handleClick}
+                onKeyDown={handleKeyDown}
+                sx={{
+                    'display': 'flex',
+                    'alignItems': 'center',
+                    'px': 2,
+                    'py': 0.75,
+                    'cursor': 'pointer',
+                    '&:hover': {
+                        backgroundColor: 'action.hover',
+                    },
+                }}
+                tabIndex={0}
+                role="button"
+                aria-expanded={isExpanded}
+            >
+                {isExpanded ? <KeyboardArrowUpIcon fontSize="small" sx={{ mr: 1 }} /> : <KeyboardArrowDownIcon fontSize="small" sx={{ mr: 1 }} />}
+                <Typography variant="body2">
+                    {subCategory.name}
+                    {activeCount > 0 && ` (${activeCount})`}
+                </Typography>
+            </Box>
+
+            <Collapse in={isExpanded}>
+                <AssetTypeList
+                    assetTypes={subCategory.assetTypes}
+                    onToggle={onToggleVisibility}
+                    disabled={isMutating}
+                    dataSourceMap={dataSourceMap}
+                    onOpenScoreFilter={onOpenScoreFilter}
+                    getScoreFilter={getScoreFilter}
+                />
+            </Collapse>
+        </Box>
+    );
+}
 
 type AssetTypeListItemProps = {
     readonly assetType: ScenarioAssetType;
@@ -144,7 +217,7 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
     const [scoreFilterPopupOpen, setScoreFilterPopupOpen] = useState(false);
     const [scoreFilterAssetType, setScoreFilterAssetType] = useState<ScenarioAssetType | null>(null);
 
-    const { data: focusAreas, isLoading: isLoadingFocusAreas } = useQuery({
+    const { data: focusAreas } = useQuery({
         queryKey: ['focusAreas', scenarioId],
         queryFn: () => fetchFocusAreas(scenarioId!),
         enabled: !!scenarioId,
@@ -177,27 +250,14 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
     });
 
     // Update selected filter mode when focus areas data loads or selected focus area changes
-    // Also auto-select first active focus area if current selection is inactive
     useEffect(() => {
         if (focusAreas) {
             const currentScope = focusAreas.find((fa) => fa.id === selectedFocusAreaId);
-            if (!currentScope?.isActive) {
-                // Current selection is inactive, select the first active focus area
-                const firstActiveScope = focusAreas.find((fa) => fa.isActive);
-                if (firstActiveScope) {
-                    onFocusAreaSelect?.(firstActiveScope.id);
-                    setSelectedFilterMode(firstActiveScope.filterMode);
-                } else {
-                    // No active focus areas - clear the selection
-                    onFocusAreaSelect?.(null);
-                }
-                return;
-            }
             if (currentScope) {
                 setSelectedFilterMode(currentScope.filterMode);
             }
         }
-    }, [focusAreas, selectedFocusAreaId, onFocusAreaSelect]);
+    }, [focusAreas, selectedFocusAreaId]);
 
     // Expand subcategories that have visible asset types - only on initial load or focus area change
     const lastFocusAreaIdRef = useRef<string | null | undefined>(undefined);
@@ -222,14 +282,6 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
         }
         setExpandedSubCategories(visibleSubCategoryIds);
     }, [assetCategories, currentFocusAreaId]);
-
-    const handleFocusAreaChange = useCallback(
-        (event: SelectChangeEvent<string>) => {
-            const newFocusAreaId = event.target.value || null;
-            onFocusAreaSelect?.(newFocusAreaId);
-        },
-        [onFocusAreaSelect],
-    );
 
     const handleSearchChange = useCallback((value: string) => {
         setSearchQuery(value);
@@ -372,11 +424,10 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
             .filter((category): category is ScenarioAssetCategory => category !== null);
     }, [assetCategories, deferredSearchQuery, filterSubCategories]);
 
-    const focusAreaSelectValue = focusAreas && currentFocusAreaId ? currentFocusAreaId : '';
-    const hasActiveScope = focusAreas?.some((fa) => fa.isActive) ?? false;
+    const hasSelectedScope = !!selectedFocusAreaId;
 
     const renderContentArea = () => {
-        if (!hasActiveScope) {
+        if (!hasSelectedScope) {
             return null;
         }
 
@@ -426,57 +477,19 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
                             {category.name}
                         </Typography>
 
-                        {category.subCategories.map((subCategory) => {
-                            const isSubCategoryExpanded = expandedSubCategories.has(subCategory.id);
-                            const activeCount = subCategory.assetTypes.filter((at) => at.isActive).length;
-                            return (
-                                <Box key={subCategory.id}>
-                                    <Box
-                                        onClick={() => toggleSubCategory(subCategory.id)}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter' || e.key === ' ') {
-                                                e.preventDefault();
-                                                toggleSubCategory(subCategory.id);
-                                            }
-                                        }}
-                                        sx={{
-                                            'display': 'flex',
-                                            'alignItems': 'center',
-                                            'px': 2,
-                                            'py': 0.75,
-                                            'cursor': 'pointer',
-                                            '&:hover': {
-                                                backgroundColor: 'action.hover',
-                                            },
-                                        }}
-                                        tabIndex={0}
-                                        role="button"
-                                        aria-expanded={isSubCategoryExpanded}
-                                    >
-                                        {isSubCategoryExpanded ? (
-                                            <KeyboardArrowUpIcon fontSize="small" sx={{ mr: 1 }} />
-                                        ) : (
-                                            <KeyboardArrowDownIcon fontSize="small" sx={{ mr: 1 }} />
-                                        )}
-                                        <Typography variant="body2">
-                                            {subCategory.name}
-                                            {activeCount > 0 && ` (${activeCount})`}
-                                        </Typography>
-                                    </Box>
-
-                                    <Collapse in={isSubCategoryExpanded}>
-                                        <AssetTypeList
-                                            assetTypes={subCategory.assetTypes}
-                                            onToggle={handleToggleVisibility}
-                                            disabled={isMutating}
-                                            dataSourceMap={dataSourceMap}
-                                            onOpenScoreFilter={handleOpenScoreFilter}
-                                            getScoreFilter={getScoreFilterForAssetType}
-                                        />
-                                    </Collapse>
-                                </Box>
-                            );
-                        })}
+                        {category.subCategories.map((subCategory) => (
+                            <SubCategoryItem
+                                key={subCategory.id}
+                                subCategory={subCategory}
+                                isExpanded={expandedSubCategories.has(subCategory.id)}
+                                onToggleExpand={toggleSubCategory}
+                                onToggleVisibility={handleToggleVisibility}
+                                onOpenScoreFilter={handleOpenScoreFilter}
+                                getScoreFilter={getScoreFilterForAssetType}
+                                isMutating={isMutating}
+                                dataSourceMap={dataSourceMap}
+                            />
+                        ))}
                     </Box>
                 ))}
             </>
@@ -531,22 +544,14 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
             </Box>
 
             <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-                <FormControl fullWidth size="small" sx={{ mb: 2 }}>
-                    <InputLabel id="focus-area-select-label">Select visible focus area</InputLabel>
-                    <Select
-                        labelId="focus-area-select-label"
-                        value={focusAreaSelectValue}
-                        onChange={handleFocusAreaChange}
-                        label="Select visible focus area"
-                        disabled={isLoadingFocusAreas}
-                    >
-                        {focusAreas?.map((fa) => (
-                            <MenuItem key={fa.id} value={fa.id} disabled={!fa.isActive}>
-                                {fa.name}
-                            </MenuItem>
-                        ))}
-                    </Select>
-                </FormControl>
+                <Box sx={{ mb: 2 }}>
+                    <FocusAreaSelector
+                        scenarioId={scenarioId}
+                        selectedFocusAreaId={currentFocusAreaId}
+                        onFocusAreaSelect={onFocusAreaSelect ?? (() => {})}
+                        label="Select focus area"
+                    />
+                </Box>
 
                 <FormControl fullWidth size="small" sx={{ mb: 2 }}>
                     <InputLabel id="filter-mode-select-label">Select filter mode</InputLabel>
@@ -555,20 +560,20 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
                         value={selectedFilterMode}
                         onChange={handleFilterModeChange}
                         label="Select filter mode"
-                        disabled={isMutating || !hasActiveScope}
+                        disabled={isMutating || !hasSelectedScope}
                     >
                         <MenuItem value="by_asset_type">By asset type</MenuItem>
                         <MenuItem value="by_score_only">By VISTA score</MenuItem>
                     </Select>
                 </FormControl>
 
-                {!hasActiveScope && (
+                {!hasSelectedScope && (
                     <Typography variant="body2" color="text.secondary">
-                        Enable a focus area or map-wide visibility to configure asset filters
+                        Select a focus area to configure asset filters
                     </Typography>
                 )}
 
-                {hasActiveScope && selectedFilterMode === 'by_asset_type' && (
+                {hasSelectedScope && selectedFilterMode === 'by_asset_type' && (
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Box sx={{ flex: 1 }}>
                             <SearchTextField placeholder="Search for an asset" value={searchQuery} onChange={handleSearchChange} fullWidth />

--- a/frontend/src/components/map-v2/panels/ExposureView.test.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.test.tsx
@@ -235,10 +235,11 @@ describe('ExposureView', () => {
             const select = screen.getByRole('combobox');
             fireEvent.mouseDown(select);
 
+            // Inactive focus areas should now be selectable (not disabled)
             await waitFor(
                 () => {
                     const inactiveOption = screen.getByRole('option', { name: 'Focus Area 2' });
-                    expect(inactiveOption).toHaveAttribute('aria-disabled', 'true');
+                    expect(inactiveOption).not.toHaveAttribute('aria-disabled', 'true');
                 },
                 { timeout: 2000 },
             );

--- a/frontend/src/components/map-v2/panels/ExposureView.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.tsx
@@ -1,29 +1,13 @@
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
-import {
-    Box,
-    IconButton,
-    Typography,
-    ListItem,
-    ListItemText,
-    Collapse,
-    Button,
-    FormControl,
-    InputLabel,
-    MenuItem,
-    Select,
-    Alert,
-    Portal,
-    Snackbar,
-} from '@mui/material';
-import type { SelectChangeEvent } from '@mui/material';
+import { Box, IconButton, Typography, ListItem, ListItemText, Collapse, Button, Alert, Portal, Snackbar } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Feature } from 'geojson';
 
+import FocusAreaSelector from './FocusAreaSelector';
 import { fetchExposureLayers, toggleExposureLayerVisibility, type ExposureLayerGroup } from '@/api/exposure-layers';
-import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
 import IconToggle from '@/components/IconToggle';
 
 const getGroupNamesWithActiveLayers = (groups: ExposureLayerGroup[]): Set<string> => {
@@ -189,28 +173,6 @@ const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSel
     const queryClient = useQueryClient();
     const currentFocusAreaId = selectedFocusAreaId ?? null;
 
-    const { data: focusAreas, isLoading: isLoadingFocusAreas } = useQuery({
-        queryKey: ['focusAreas', scenarioId],
-        queryFn: () => fetchFocusAreas(scenarioId!),
-        enabled: !!scenarioId,
-        staleTime: 5 * 60 * 1000,
-    });
-
-    // Auto-select first active focus area when current selection is inactive
-    useEffect(() => {
-        if (focusAreas) {
-            const currentScope = focusAreas.find((fa) => fa.id === selectedFocusAreaId);
-            if (!currentScope?.isActive) {
-                const firstActiveScope = focusAreas.find((fa) => fa.isActive);
-                if (firstActiveScope) {
-                    onFocusAreaSelect?.(firstActiveScope.id);
-                } else {
-                    onFocusAreaSelect?.(null);
-                }
-            }
-        }
-    }, [focusAreas, selectedFocusAreaId, onFocusAreaSelect]);
-
     const {
         data: exposureLayersData,
         isLoading: isLoadingLayers,
@@ -259,13 +221,6 @@ const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSel
         });
     }, []);
 
-    const handleFocusAreaChange = useCallback(
-        (event: SelectChangeEvent<string>) => {
-            onFocusAreaSelect?.(event.target.value || null);
-        },
-        [onFocusAreaSelect],
-    );
-
     const toggleExposureLayer = useCallback(
         (layerId: string) => {
             const currentState = exposureLayersData?.groups.flatMap((g) => g.exposureLayers).find((l) => l.id === layerId)?.isActive ?? false;
@@ -312,7 +267,6 @@ const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSel
         return buildLayerVisibilityMap(exposureLayersData.groups);
     }, [exposureLayersData]);
 
-    const focusAreaSelectValue = focusAreas && currentFocusAreaId ? currentFocusAreaId : '';
     const isMutating = visibilityMutation.isPending;
 
     if (!scenarioId) {
@@ -364,22 +318,12 @@ const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSel
                 </Box>
 
                 <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
-                    <FormControl fullWidth size="small">
-                        <InputLabel id="focus-area-select-label">Focus area</InputLabel>
-                        <Select
-                            labelId="focus-area-select-label"
-                            value={focusAreaSelectValue}
-                            onChange={handleFocusAreaChange}
-                            label="Focus area"
-                            disabled={isLoadingFocusAreas}
-                        >
-                            {focusAreas?.map((fa: FocusArea) => (
-                                <MenuItem key={fa.id} value={fa.id} disabled={!fa.isActive}>
-                                    {fa.name}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FormControl>
+                    <FocusAreaSelector
+                        scenarioId={scenarioId}
+                        selectedFocusAreaId={currentFocusAreaId}
+                        onFocusAreaSelect={onFocusAreaSelect ?? (() => {})}
+                        label="Focus area"
+                    />
                 </Box>
 
                 <Box sx={{ flex: 1, overflowY: 'auto', position: 'relative' }}>

--- a/frontend/src/components/map-v2/panels/FocusAreaSelector.test.tsx
+++ b/frontend/src/components/map-v2/panels/FocusAreaSelector.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@mui/material/styles';
+
+import FocusAreaSelector from './FocusAreaSelector';
+import theme from '@/theme';
+import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
+
+vi.mock('@/api/focus-areas', () => ({
+    fetchFocusAreas: vi.fn(),
+}));
+
+const mockedFetchFocusAreas = vi.mocked(fetchFocusAreas);
+
+describe('FocusAreaSelector', () => {
+    let queryClient: QueryClient;
+
+    const defaultProps = {
+        scenarioId: 'scenario-123',
+        selectedFocusAreaId: null,
+        onFocusAreaSelect: vi.fn(),
+    };
+
+    beforeEach(() => {
+        queryClient = new QueryClient({
+            defaultOptions: {
+                queries: { retry: false },
+            },
+        });
+        vi.clearAllMocks();
+    });
+
+    const renderWithProviders = (component: React.ReactElement) => {
+        return render(
+            <QueryClientProvider client={queryClient}>
+                <ThemeProvider theme={theme}>{component}</ThemeProvider>
+            </QueryClientProvider>,
+        );
+    };
+
+    const createMockFocusArea = (overrides?: Partial<FocusArea>): FocusArea => ({
+        id: 'focus-area-1',
+        name: 'Test Focus Area',
+        geometry: null,
+        filterMode: 'by_asset_type',
+        isActive: true,
+        isSystem: false,
+        ...overrides,
+    });
+
+    describe('Rendering', () => {
+        it('renders with default label', async () => {
+            mockedFetchFocusAreas.mockResolvedValue([]);
+            renderWithProviders(<FocusAreaSelector {...defaultProps} />);
+
+            expect(screen.getByLabelText('Select focus area')).toBeInTheDocument();
+        });
+
+        it('renders with custom label', async () => {
+            mockedFetchFocusAreas.mockResolvedValue([]);
+            renderWithProviders(<FocusAreaSelector {...defaultProps} label="Focus area" />);
+
+            expect(screen.getByLabelText('Focus area')).toBeInTheDocument();
+        });
+
+        it('renders focus areas as options', async () => {
+            const focusAreas = [createMockFocusArea({ id: 'fa-1', name: 'Area One' }), createMockFocusArea({ id: 'fa-2', name: 'Area Two' })];
+            mockedFetchFocusAreas.mockResolvedValue(focusAreas);
+
+            renderWithProviders(<FocusAreaSelector {...defaultProps} />);
+
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalledWith('scenario-123');
+            });
+
+            const select = screen.getByRole('combobox');
+            await userEvent.click(select);
+
+            expect(screen.getByRole('option', { name: 'Area One' })).toBeInTheDocument();
+            expect(screen.getByRole('option', { name: 'Area Two' })).toBeInTheDocument();
+        });
+
+        it('displays selected focus area name', async () => {
+            const focusAreas = [createMockFocusArea({ id: 'fa-1', name: 'Selected Area' })];
+            mockedFetchFocusAreas.mockResolvedValue(focusAreas);
+
+            renderWithProviders(<FocusAreaSelector {...defaultProps} selectedFocusAreaId="fa-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByRole('combobox')).toHaveTextContent('Selected Area');
+            });
+        });
+    });
+
+    describe('Selection', () => {
+        it('calls onFocusAreaSelect when option is selected', async () => {
+            const onFocusAreaSelect = vi.fn();
+            const focusAreas = [createMockFocusArea({ id: 'fa-1', name: 'Area One' })];
+            mockedFetchFocusAreas.mockResolvedValue(focusAreas);
+
+            renderWithProviders(<FocusAreaSelector {...defaultProps} onFocusAreaSelect={onFocusAreaSelect} />);
+
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            const select = screen.getByRole('combobox');
+            await userEvent.click(select);
+            await userEvent.click(screen.getByRole('option', { name: 'Area One' }));
+
+            expect(onFocusAreaSelect).toHaveBeenCalledWith('fa-1');
+        });
+    });
+
+    describe('Disabled state', () => {
+        it('is disabled when disabled prop is true', async () => {
+            mockedFetchFocusAreas.mockResolvedValue([]);
+            renderWithProviders(<FocusAreaSelector {...defaultProps} disabled />);
+
+            const select = screen.getByRole('combobox');
+            expect(select).toHaveAttribute('aria-disabled', 'true');
+        });
+
+        it('is disabled while loading', async () => {
+            const pendingPromise = new Promise<never>(() => {});
+            mockedFetchFocusAreas.mockReturnValue(pendingPromise);
+            renderWithProviders(<FocusAreaSelector {...defaultProps} />);
+
+            const select = screen.getByRole('combobox');
+            expect(select).toHaveAttribute('aria-disabled', 'true');
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('shows empty value when selectedFocusAreaId does not match any focus area', async () => {
+            const focusAreas = [createMockFocusArea({ id: 'fa-1', name: 'Area One' })];
+            mockedFetchFocusAreas.mockResolvedValue(focusAreas);
+
+            renderWithProviders(<FocusAreaSelector {...defaultProps} selectedFocusAreaId="non-existent" />);
+
+            await waitFor(() => {
+                expect(mockedFetchFocusAreas).toHaveBeenCalled();
+            });
+
+            const select = screen.getByRole('combobox');
+            expect(select).not.toHaveTextContent('Area One');
+        });
+
+        it('does not fetch when scenarioId is undefined', () => {
+            mockedFetchFocusAreas.mockResolvedValue([]);
+            renderWithProviders(<FocusAreaSelector {...defaultProps} scenarioId={undefined} />);
+
+            expect(mockedFetchFocusAreas).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/src/components/map-v2/panels/FocusAreaSelector.tsx
+++ b/frontend/src/components/map-v2/panels/FocusAreaSelector.tsx
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { fetchFocusAreas, type FocusArea } from '@/api/focus-areas';
+
+type FocusAreaSelectorProps = {
+    readonly scenarioId: string | undefined;
+    readonly selectedFocusAreaId: string | null;
+    readonly onFocusAreaSelect: (focusAreaId: string | null) => void;
+    readonly label?: string;
+    readonly disabled?: boolean;
+};
+
+const FocusAreaSelector = ({ scenarioId, selectedFocusAreaId, onFocusAreaSelect, label = 'Select focus area', disabled }: FocusAreaSelectorProps) => {
+    const { data: focusAreas, isLoading } = useQuery({
+        queryKey: ['focusAreas', scenarioId],
+        queryFn: () => fetchFocusAreas(scenarioId!),
+        enabled: !!scenarioId,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    const handleChange = useCallback(
+        (event: SelectChangeEvent<string>) => {
+            onFocusAreaSelect(event.target.value || null);
+        },
+        [onFocusAreaSelect],
+    );
+
+    const selectValue = focusAreas?.find((fa) => fa.id === selectedFocusAreaId) ? selectedFocusAreaId : '';
+
+    return (
+        <FormControl fullWidth size="small">
+            <InputLabel id="focus-area-select-label">{label}</InputLabel>
+            <Select labelId="focus-area-select-label" value={selectValue ?? ''} onChange={handleChange} label={label} disabled={disabled || isLoading}>
+                {focusAreas?.map((fa: FocusArea) => (
+                    <MenuItem key={fa.id} value={fa.id}>
+                        {fa.name}
+                    </MenuItem>
+                ))}
+            </Select>
+        </FormControl>
+    );
+};
+
+export default FocusAreaSelector;

--- a/frontend/src/components/map-v2/panels/FocusAreaView.tsx
+++ b/frontend/src/components/map-v2/panels/FocusAreaView.tsx
@@ -29,15 +29,19 @@ type FocusAreaViewProps = {
     readonly scenarioId?: string;
     readonly isDrawing?: boolean;
     readonly onStartDrawing?: (mode: 'circle' | 'polygon') => void;
+    readonly selectedFocusAreaId?: string | null;
+    readonly onFocusAreaSelect?: (focusAreaId: string | null) => void;
 };
 
 type FocusAreaItemProps = {
     readonly focusArea: FocusArea;
     readonly scenarioId: string;
     readonly onError: (message: string) => void;
+    readonly isSelected?: boolean;
+    readonly onSelect?: (focusAreaId: string) => void;
 };
 
-const FocusAreaItem = ({ focusArea, scenarioId, onError }: FocusAreaItemProps) => {
+const FocusAreaItem = ({ focusArea, scenarioId, onError, isSelected, onSelect }: FocusAreaItemProps) => {
     const [isEditing, setIsEditing] = useState(false);
     const [editName, setEditName] = useState(focusArea.name);
     const [nameError, setNameError] = useState<string | null>(null);
@@ -45,7 +49,12 @@ const FocusAreaItem = ({ focusArea, scenarioId, onError }: FocusAreaItemProps) =
 
     const { updateFocusArea: updateFocusAreaMutate, deleteFocusArea: deleteFocusAreaMutate, isMutating } = useFocusAreaMutations({ scenarioId, onError });
 
-    const handleEditClick = () => {
+    const handleClick = () => {
+        onSelect?.(focusArea.id);
+    };
+
+    const handleEditClick = (e: MouseEvent) => {
+        e.stopPropagation();
         setEditName(focusArea.name);
         setNameError(null);
         setIsEditing(true);
@@ -81,11 +90,13 @@ const FocusAreaItem = ({ focusArea, scenarioId, onError }: FocusAreaItemProps) =
         }
     };
 
-    const handleToggleVisibility = () => {
+    const handleToggleVisibility = (e: MouseEvent | KeyboardEvent) => {
+        e.stopPropagation();
         updateFocusAreaMutate({ focusAreaId: focusArea.id, data: { isActive: !focusArea.isActive } });
     };
 
-    const handleDeleteClick = () => {
+    const handleDeleteClick = (e: MouseEvent) => {
+        e.stopPropagation();
         setDeleteDialogOpen(true);
     };
 
@@ -100,12 +111,18 @@ const FocusAreaItem = ({ focusArea, scenarioId, onError }: FocusAreaItemProps) =
 
     return (
         <Box
+            onClick={handleClick}
             sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                py: 1,
-                px: 2,
+                'display': 'flex',
+                'alignItems': 'center',
+                'justifyContent': 'space-between',
+                'py': 1,
+                'px': 2,
+                'cursor': 'pointer',
+                'backgroundColor': isSelected ? 'action.selected' : 'transparent',
+                '&:hover': {
+                    backgroundColor: isSelected ? 'action.selected' : 'action.hover',
+                },
             }}
         >
             <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -174,7 +191,7 @@ const FocusAreaItem = ({ focusArea, scenarioId, onError }: FocusAreaItemProps) =
     );
 };
 
-const FocusAreaView = ({ onClose, scenarioId, isDrawing, onStartDrawing }: FocusAreaViewProps) => {
+const FocusAreaView = ({ onClose, scenarioId, isDrawing, onStartDrawing, selectedFocusAreaId, onFocusAreaSelect }: FocusAreaViewProps) => {
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const [mutationError, setMutationError] = useState<string | null>(null);
     const menuOpen = Boolean(menuAnchorEl);
@@ -216,7 +233,8 @@ const FocusAreaView = ({ onClose, scenarioId, isDrawing, onStartDrawing }: Focus
         onStartDrawing?.('polygon');
     }, [onStartDrawing]);
 
-    const handleMapWideToggle = () => {
+    const handleMapWideToggle = (e: MouseEvent | KeyboardEvent) => {
+        e.stopPropagation();
         if (mapWideFocusArea) {
             updateFocusAreaMutate({ focusAreaId: mapWideFocusArea.id, data: { isActive: !mapWideVisible } });
         }
@@ -235,12 +253,18 @@ const FocusAreaView = ({ onClose, scenarioId, isDrawing, onStartDrawing }: Focus
 
             <Box sx={{ flex: 1, overflowY: 'auto' }}>
                 <Box
+                    onClick={() => mapWideFocusArea && onFocusAreaSelect?.(mapWideFocusArea.id)}
                     sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        py: 1.5,
-                        px: 2,
+                        'display': 'flex',
+                        'alignItems': 'center',
+                        'justifyContent': 'space-between',
+                        'py': 1.5,
+                        'px': 2,
+                        'cursor': 'pointer',
+                        'backgroundColor': selectedFocusAreaId === mapWideFocusArea?.id ? 'action.selected' : 'transparent',
+                        '&:hover': {
+                            backgroundColor: selectedFocusAreaId === mapWideFocusArea?.id ? 'action.selected' : 'action.hover',
+                        },
                     }}
                 >
                     <Typography variant="body2">Map-wide</Typography>
@@ -283,7 +307,14 @@ const FocusAreaView = ({ onClose, scenarioId, isDrawing, onStartDrawing }: Focus
                     !isLoading &&
                     !isError &&
                     userFocusAreas.map((focusArea) => (
-                        <FocusAreaItem key={focusArea.id} focusArea={focusArea} scenarioId={scenarioId} onError={setMutationError} />
+                        <FocusAreaItem
+                            key={focusArea.id}
+                            focusArea={focusArea}
+                            scenarioId={scenarioId}
+                            onError={setMutationError}
+                            isSelected={selectedFocusAreaId === focusArea.id}
+                            onSelect={onFocusAreaSelect}
+                        />
                     ))}
 
                 <Box sx={{ display: 'flex', justifyContent: 'center', m: 2 }}>

--- a/frontend/src/components/map-v2/panels/GlobalScoreFilter.tsx
+++ b/frontend/src/components/map-v2/panels/GlobalScoreFilter.tsx
@@ -27,6 +27,7 @@ export function GlobalScoreFilter({ onApply, onClear, initialValues, disabled }:
         handleCheckboxChange,
         buildFilterPayload,
         resetToDefaults,
+        isValidRange,
     } = useScoreFilterState({ initialValues });
 
     const handleApply = useCallback(() => {
@@ -69,7 +70,7 @@ export function GlobalScoreFilter({ onApply, onClear, initialValues, disabled }:
                 <IconButton size="small" onClick={handleClear} disabled={disabled} title="Clear filter">
                     <LayersClearOutlined fontSize="small" />
                 </IconButton>
-                <Button variant="contained" size="small" onClick={handleApply} disabled={disabled}>
+                <Button variant="contained" size="small" onClick={handleApply} disabled={disabled || !isValidRange()}>
                     Apply
                 </Button>
             </Box>

--- a/frontend/src/components/map-v2/panels/ScoreFilterPopup.tsx
+++ b/frontend/src/components/map-v2/panels/ScoreFilterPopup.tsx
@@ -26,6 +26,7 @@ export function ScoreFilterPopup({ open, onClose, onApply, assetTypeName, initia
         setDependencyMax,
         handleCheckboxChange,
         buildFilterPayload,
+        isValidRange,
     } = useScoreFilterState({ initialValues });
 
     const handleApply = useCallback(() => {
@@ -79,7 +80,7 @@ export function ScoreFilterPopup({ open, onClose, onApply, assetTypeName, initia
                 <Button onClick={onClose} variant="outlined" size="small" sx={{ minWidth: 96 }}>
                     Cancel
                 </Button>
-                <Button onClick={handleApply} variant="contained" size="small" sx={{ minWidth: 96 }}>
+                <Button onClick={handleApply} variant="contained" size="small" sx={{ minWidth: 96 }} disabled={!isValidRange()}>
                     Apply
                 </Button>
             </DialogActions>

--- a/frontend/src/hooks/useScenarioAssets.ts
+++ b/frontend/src/hooks/useScenarioAssets.ts
@@ -3,13 +3,14 @@ import { fetchScenarioAssets } from '@/api/scenario-assets';
 
 export type UseScenarioAssetsOptions = {
     scenarioId: string | undefined;
+    focusAreaId?: string | null;
     iconMap?: Map<string, string>;
 };
 
-export const useScenarioAssets = ({ scenarioId, iconMap }: UseScenarioAssetsOptions) => {
+export const useScenarioAssets = ({ scenarioId, focusAreaId, iconMap }: UseScenarioAssetsOptions) => {
     const query = useQuery({
-        queryKey: ['scenarioAssets', scenarioId],
-        queryFn: () => fetchScenarioAssets({ scenarioId: scenarioId!, iconMap }),
+        queryKey: ['scenarioAssets', scenarioId, focusAreaId ?? 'all'],
+        queryFn: () => fetchScenarioAssets({ scenarioId: scenarioId!, focusAreaId, iconMap }),
         enabled: !!scenarioId,
         staleTime: 5 * 60 * 1000,
     });


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Adds back asset isolation per focus area that was removed, now done on the backend and supports the by_score filtering.

Asset selection is still persisted through panels, but now indicates selection and allows selection via the map.

Focus areas are no longer drawn in the other areas as draw components, so they are not editable, we use different layers to display them.

Disabled focus areas are now editable in the Asset & Exposure panels, if they are selected in the map view they'll show as a gray lined area, this is to allow moving through the different panels while keeping the same focus area selected.

## Description

- Add FocusAreaSelector dropdown component for panel-level focus area selection
- Add FocusAreaOutline component to render dashed outline for inactive focus areas
- Sync focus area selection bi-directionally between panels and MapboxDraw
- Pass focusAreaId to scenario assets API to filter assets by focus area
- Update useFocusAreas hook with selectedFocusAreaId sync and selection events

## How Has This Been Tested?

Locally & tests

## Screenshots (if appropriate):
<img width="1549" height="756" alt="Screenshot 2025-12-19 at 11 31 43" src="https://github.com/user-attachments/assets/5c179acd-7137-42f0-a69e-67b3aa31e0ce" />
<img width="1562" height="744" alt="Screenshot 2025-12-19 at 11 31 34" src="https://github.com/user-attachments/assets/c28f9cff-b138-4e08-b136-31ee8ced7729" />
<img width="1966" height="759" alt="Screenshot 2025-12-19 at 11 31 20" src="https://github.com/user-attachments/assets/338dbafa-3898-4751-b690-895f6dc738e3" />
<img width="1964" height="762" alt="Screenshot 2025-12-19 at 11 31 12" src="https://github.com/user-attachments/assets/732e327f-75a4-449e-aa09-590153cb8a73" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ x] I have added tests to cover my changes.
