### PR TITLE
bugfix(DPAV-1983): ensure selectedFocusAreaId is valid

### DIFF
--- a/frontend/src/components/map-v2/MapView.test.tsx
+++ b/frontend/src/components/map-v2/MapView.test.tsx
@@ -48,8 +48,11 @@ vi.mock('react-map-gl/maplibre', () => ({
                 on: vi.fn(),
                 off: vi.fn(),
                 easeTo: vi.fn(),
+                flyTo: vi.fn(),
+                fitBounds: vi.fn(),
                 zoomIn: vi.fn(),
                 zoomOut: vi.fn(),
+                getCanvas: vi.fn(() => ({ style: {} })),
             }),
         }));
 
@@ -71,8 +74,11 @@ vi.mock('react-map-gl/maplibre', () => ({
                 on: vi.fn(),
                 off: vi.fn(),
                 easeTo: vi.fn(),
+                flyTo: vi.fn(),
+                fitBounds: vi.fn(),
                 zoomIn: vi.fn(),
                 zoomOut: vi.fn(),
+                getCanvas: vi.fn(() => ({ style: {} })),
             }),
         },
     })),
@@ -87,6 +93,8 @@ vi.mock('./MapPanels', () => {
         onUtilityToggle,
         onRoadRouteVehicleChange,
         roadRouteVehicle,
+        selectedFocusAreaId,
+        onFocusAreaSelect,
     }: {
         activeView: string | null;
         onViewChange: (view: string | null) => void;
@@ -95,6 +103,8 @@ vi.mock('./MapPanels', () => {
         onUtilityToggle?: (utilityId: string, enabled: boolean) => void;
         onRoadRouteVehicleChange?: (vehicle: any) => void;
         roadRouteVehicle?: string;
+        selectedFocusAreaId?: string | null;
+        onFocusAreaSelect?: (focusAreaId: string | null) => void;
     }) => {
         const [roadRouteEnabled, setRoadRouteEnabled] = React.useState(false);
 
@@ -113,9 +123,13 @@ vi.mock('./MapPanels', () => {
                 <button onClick={() => onRoadRouteVehicleChange?.('HGV')} data-testid="set-vehicle-hgv">
                     Set Vehicle HGV
                 </button>
+                <button onClick={() => onFocusAreaSelect?.('user-focus-area-1')} data-testid="select-user-focus-area">
+                    Select User Focus Area
+                </button>
                 <div data-testid="vehicle-value">{roadRouteVehicle || 'Car'}</div>
                 <div data-testid="active-view">{activeView || 'none'}</div>
                 <div data-testid="selected-element">{selectedElement?.id || 'none'}</div>
+                <div data-testid="selected-focus-area-id">{selectedFocusAreaId || 'none'}</div>
                 {onBackFromAssetDetails && <button onClick={onBackFromAssetDetails}>Back from Asset Details</button>}
             </div>
         );
@@ -177,8 +191,9 @@ vi.mock('@/hooks/useActiveScenario', () => ({
     }),
 }));
 
+const mockFetchFocusAreas = vi.fn();
 vi.mock('@/api/focus-areas', () => ({
-    fetchFocusAreas: vi.fn().mockResolvedValue([]),
+    fetchFocusAreas: (...args: any[]) => mockFetchFocusAreas(...args),
     createFocusArea: vi.fn().mockResolvedValue({ id: 'new-focus-area', name: 'Area 1', isActive: true }),
 }));
 
@@ -200,6 +215,7 @@ describe('MapView', () => {
         });
         mockUseAssetTypeIcons.mockReturnValue(new Map());
         mockFetchAssetCategories.mockResolvedValue([]);
+        mockFetchFocusAreas.mockResolvedValue([]);
     });
 
     describe('Rendering', () => {
@@ -345,6 +361,55 @@ describe('MapView', () => {
         it('sets mapReady when map loads', async () => {
             renderWithProviders(<MapView />);
             await waitForElement('map');
+        });
+    });
+
+    describe('Focus Area Selection', () => {
+        it('auto-selects map-wide focus area on initial load', async () => {
+            mockFetchFocusAreas.mockResolvedValue([
+                { id: 'map-wide-id', name: 'Map-wide', isSystem: true, isActive: true },
+                { id: 'user-focus-area-1', name: 'User Area 1', isSystem: false, isActive: true },
+            ]);
+
+            renderWithProviders(<MapView />);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-focus-area-id')).toHaveTextContent('map-wide-id');
+            });
+        });
+
+        it('resets to map-wide when selected focus area is deleted', async () => {
+            const queryClient = createTestQueryClient();
+
+            mockFetchFocusAreas.mockResolvedValue([
+                { id: 'map-wide-id', name: 'Map-wide', isSystem: true, isActive: true },
+                { id: 'user-focus-area-1', name: 'User Area 1', isSystem: false, isActive: true },
+            ]);
+
+            renderWithProviders(<MapView />, queryClient);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-focus-area-id')).toHaveTextContent('map-wide-id');
+            });
+
+            const selectUserFocusAreaButton = screen.getByTestId('select-user-focus-area');
+            await act(async () => {
+                selectUserFocusAreaButton.click();
+            });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-focus-area-id')).toHaveTextContent('user-focus-area-1');
+            });
+
+            mockFetchFocusAreas.mockResolvedValue([{ id: 'map-wide-id', name: 'Map-wide', isSystem: true, isActive: true }]);
+
+            await act(async () => {
+                queryClient.invalidateQueries({ queryKey: ['focusAreas'] });
+            });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('selected-focus-area-id')).toHaveTextContent('map-wide-id');
+            });
         });
     });
 });

--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -96,13 +96,18 @@ const MapView = () => {
         [focusAreas, mapReady],
     );
 
-    // Auto-select map-wide focus area when focusAreas loads and nothing is selected
     useEffect(() => {
-        if (focusAreas && !selectedFocusAreaId) {
-            const mapWideFocusArea = focusAreas.find((fa) => fa.isSystem);
-            if (mapWideFocusArea) {
-                setSelectedFocusAreaId(mapWideFocusArea.id);
+        if (!focusAreas) {
+            if (selectedFocusAreaId) {
+                setSelectedFocusAreaId(null);
             }
+            return;
+        }
+
+        const selectionValid = selectedFocusAreaId && focusAreas.some((fa) => fa.id === selectedFocusAreaId);
+        if (!selectionValid) {
+            const mapWideFocusArea = focusAreas.find((fa) => fa.isSystem);
+            setSelectedFocusAreaId(mapWideFocusArea?.id ?? null);
         }
     }, [focusAreas, selectedFocusAreaId]);
 

--- a/frontend/src/components/map-v2/panels/FocusAreaView.tsx
+++ b/frontend/src/components/map-v2/panels/FocusAreaView.tsx
@@ -100,7 +100,8 @@ const FocusAreaItem = ({ focusArea, scenarioId, onError, isSelected, onSelect }:
         setDeleteDialogOpen(true);
     };
 
-    const handleDeleteConfirm = () => {
+    const handleDeleteConfirm = (e: MouseEvent) => {
+        e.stopPropagation();
         setDeleteDialogOpen(false);
         deleteFocusAreaMutate(focusArea.id);
     };


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Deleting focus area left it selected and caused issues when switching to other tabs as it tried to fetch the assets/focus areas for the now invalid focus area id.

https://ndtp.atlassian.net/browse/DPAV-1983?focusedCommentId=15415

## Description

Resolves issue where the selected focus area is set to a focus area that has just been deleted (caused by event propagating), improved useEffect to ensure that the selected value is valid.

## How Has This Been Tested?

Locally/unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
