### PR TITLE
bugfix(DPAV-2019): fix user-specific scores select in asset filter

### DIFF
--- a/backend/vista-python-api/src/api/filters/asset_filter.py
+++ b/backend/vista-python-api/src/api/filters/asset_filter.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from django.contrib.gis.geos import Polygon
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 
 from api.models import AssetScoreFilter
 from api.models.asset_score import AssetScore
@@ -43,9 +43,15 @@ class AssetFilterBuilder:
 
     def _score_subquery(self, score_filter: AssetScoreFilter | None = None):
         """Build subquery for asset IDs matching score criteria."""
-        query = AssetScore.objects.filter(scenario_id=self.ctx.scenario_id).filter(
-            Q(user_id=self.ctx.user_id) | Q(user_id__isnull=True)
+        user_score_exists = AssetScore.objects.filter(
+            scenario_id=self.ctx.scenario_id,
+            user_id=self.ctx.user_id,
+            id=OuterRef("id"),
         )
+        query = AssetScore.objects.filter(scenario_id=self.ctx.scenario_id).filter(
+            Q(user_id=self.ctx.user_id) | (Q(user_id__isnull=True) & ~Exists(user_score_exists))
+        )
+
         if score_filter is not None:
             if score_filter.criticality_values is not None:
                 query = query.filter(

--- a/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
+++ b/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
@@ -4,11 +4,20 @@
 import uuid
 
 import pytest
-from django.contrib.gis.geos import GEOSGeometry, Point
+from django.contrib.gis.geos import GEOSGeometry, Point, Polygon
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 
-from api.models import AssetScoreFilter, FocusArea, Scenario, ScenarioAsset, VisibleAsset
+from api.models import (
+    AssetScoreFilter,
+    ExposureLayer,
+    ExposureLayerType,
+    FocusArea,
+    Scenario,
+    ScenarioAsset,
+    VisibleAsset,
+    VisibleExposureLayer,
+)
 from api.models.asset import Asset
 from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
 
@@ -1453,3 +1462,84 @@ def test_asset_types_filtered_count_with_score_filter(
 
     # Pylon has no score filter, so filteredAssetCount equals assetCount
     assert pylon_data["filteredAssetCount"] == pylon_data["assetCount"]
+
+
+@pytest.mark.django_db
+def test_exposure_filter_uses_user_specific_scores(scenario, mock_user_id, client):
+    """Test that exposure filtering uses user-specific scores over fallback null scores.
+
+    The asset_scores view contains both user-specific rows (with actual exposure scores)
+    and fallback NULL user rows (with exposure=0). This test verifies that the filter
+    prioritizes user-specific scores when they exist.
+    """
+    # Create asset type and scenario asset
+    category = AssetCategory.objects.create(id=uuid.uuid4(), name="Exposure Test Category")
+    sub_category = AssetSubCategory.objects.create(
+        id=uuid.uuid4(), name="Exposure Test SubCat", category_id=category
+    )
+    data_source = DataSource.objects.create(id=uuid.uuid4(), name="Exposure Test Source")
+    asset_type = AssetType.objects.create(
+        id=uuid.uuid4(),
+        name="Exposure Test Assets",
+        sub_category_id=sub_category,
+        data_source_id=data_source,
+    )
+    ScenarioAsset.objects.create(scenario=scenario, asset_type=asset_type, criticality_score=3)
+
+    # Create exposure layer polygon centered at origin
+    exposure_poly = Polygon(
+        ((-0.001, -0.001), (0.001, -0.001), (0.001, 0.001), (-0.001, 0.001), (-0.001, -0.001))
+    )
+    exposure_layer_type = ExposureLayerType.objects.create(name="Test Flood")
+    exposure_layer = ExposureLayer.objects.create(geometry=exposure_poly, type=exposure_layer_type)
+
+    # Create asset INSIDE exposure layer (should get exposure score = 2)
+    Asset.objects.create(
+        id=uuid.uuid4(),
+        external_id=uuid.uuid4(),
+        name="Asset Inside Exposure",
+        type=asset_type,
+        geom=Point(0.0, 0.0),  # Inside the exposure polygon
+    )
+
+    # Create asset OUTSIDE exposure layer (should get exposure score = 0)
+    Asset.objects.create(
+        id=uuid.uuid4(),
+        external_id=uuid.uuid4(),
+        name="Asset Outside Exposure",
+        type=asset_type,
+        geom=Point(1.0, 1.0),  # Well outside the exposure polygon
+    )
+
+    # Create focus area with by_score_only mode and exposure filter = [0]
+    fa = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Exposure Filter Test FA",
+        geometry=None,  # Map-wide
+        filter_mode="by_score_only",
+        is_active=True,
+        is_system=True,
+    )
+
+    # Link exposure layer to this focus area (for this user)
+    VisibleExposureLayer.objects.create(focus_area=fa, exposure_layer=exposure_layer)
+
+    # Create global score filter requiring exposure = 0 only
+    AssetScoreFilter.objects.create(focus_area=fa, asset_type=None, exposure_values=[0])
+
+    # Refresh materialized view so exposure scores are computed
+    with connection.cursor() as cursor:
+        cursor.execute("REFRESH MATERIALIZED VIEW public.assets_within_500m_exposure_layers;")
+
+    # Query assets with exposure filter
+    response = client.get(f"/api/scenarios/{scenario.id}/assets/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+
+    # Only asset_outside should be returned (exposure=0 for user with visible exposure layer)
+    # asset_inside has exposure=2 for this user (inside 1 exposure layer) and should be excluded
+    returned_names = [a["name"] for a in data]
+    assert len(data) == 1, f"Expected 1 asset, got {len(data)}: {returned_names}"
+    assert data[0]["name"] == "Asset Outside Exposure"


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-2019?focusedCommentId=15635

> When using ‘By VISTA score’ filter with a value of '0', it will still display Assets that have an exposure score of 1/2/3 on the map.


## Description

The score filter was matching both user-specific and the fallback NULL user_id rows from asset_scores.


## How Has This Been Tested?

Unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
