### PR TITLE
bugfix(DPAV-1977): clear asset filters when clear all is pressed

### DIFF
--- a/backend/vista-python-api/src/api/tests/views/test_visible_asset_types.py
+++ b/backend/vista-python-api/src/api/tests/views/test_visible_asset_types.py
@@ -6,7 +6,7 @@ import uuid
 import pytest
 from django.contrib.gis.geos import GEOSGeometry, Point
 
-from api.models import FocusArea, Scenario, VisibleAsset
+from api.models import AssetScoreFilter, FocusArea, Scenario, VisibleAsset
 from api.models.asset import Asset
 from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
 
@@ -424,3 +424,39 @@ def test_delete_with_no_visible_assets(scenario, mapwide_focus_area, client):
 
     assert response.status_code == http_success_code
     assert data["success"] is True
+
+
+@pytest.mark.django_db
+def test_delete_clears_per_asset_type_score_filters(scenario, asset_type, focus_area, client):
+    """Test DELETE clears per-asset-type score filters but preserves global filter."""
+    # Create a per-asset-type score filter
+    per_type_filter = AssetScoreFilter.objects.create(
+        focus_area=focus_area,
+        asset_type=asset_type,
+        criticality_values=[1, 2],
+    )
+
+    # Create a global score filter (asset_type=NULL)
+    global_filter = AssetScoreFilter.objects.create(
+        focus_area=focus_area,
+        asset_type=None,
+        criticality_values=[3, 4],
+    )
+
+    # Create visibility
+    VisibleAsset.objects.create(
+        focus_area=focus_area,
+        asset_type=asset_type,
+    )
+
+    response = client.delete(
+        f"/api/scenarios/{scenario.id}/visible-asset-types/?focus_area_id={focus_area.id}"
+    )
+
+    assert response.status_code == http_success_code
+
+    # Per-asset-type filter should be deleted
+    assert not AssetScoreFilter.objects.filter(id=per_type_filter.id).exists()
+
+    # Global filter should still exist
+    assert AssetScoreFilter.objects.filter(id=global_filter.id).exists()

--- a/backend/vista-python-api/src/api/views/visible_asset_types.py
+++ b/backend/vista-python-api/src/api/views/visible_asset_types.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from api.models import AssetType, FocusArea, Scenario, VisibleAsset
+from api.models import AssetScoreFilter, AssetType, FocusArea, Scenario, VisibleAsset
 from api.serializers import (
     VisibleAssetTypeResponseSerializer,
     VisibleAssetTypeToggleSerializer,
@@ -79,5 +79,6 @@ class VisibleAssetTypeView(APIView):
         )
 
         VisibleAsset.objects.filter(focus_area=focus_area).delete()
+        AssetScoreFilter.objects.filter(focus_area=focus_area, asset_type__isnull=False).delete()
 
         return Response({"success": True}, status=status.HTTP_200_OK)

--- a/frontend/src/components/map-v2/hooks/useAssetFilterMutations.ts
+++ b/frontend/src/components/map-v2/hooks/useAssetFilterMutations.ts
@@ -43,6 +43,7 @@ const useAssetFilterMutations = ({ scenarioId, selectedFocusAreaId, selectedFilt
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['scenarioAssetTypes', scenarioId] });
             queryClient.invalidateQueries({ queryKey: ['scenarioAssets', scenarioId] });
+            queryClient.invalidateQueries({ queryKey: ['assetScoreFilters', scenarioId] });
         },
         onError: () => onError?.('Failed to clear asset type visibility'),
     });


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-1977?focusedCommentId=15418

## Description

Delete asset filters when deleting all the visible assets 

## How Has This Been Tested?

Locally / tests 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
