### PR TITLE
bugfix(DPAV-2019): set refetchOnMount to true for asset scores

### DIFF
--- a/frontend/src/components/map-v2/panels/AssetDetailsPanel.tsx
+++ b/frontend/src/components/map-v2/panels/AssetDetailsPanel.tsx
@@ -113,6 +113,7 @@ const AssetDetailsPanel = ({ selectedElement, onBack, onClose, scenarioId, onCon
         enabled: elemIsAsset && !!assetId && !!scenarioId,
         queryKey: ['asset-score', scenarioId, assetId || ''],
         queryFn: () => fetchAssetScore(scenarioId!, assetId!),
+        refetchOnMount: true,
     });
 
     const handleToggleDependentsVisibility = useCallback(() => {


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-2019?focusedCommentId=15740

Asset panel is showing stale data after toggling exposure layers

## Description

Refetch the asset scores if its been invalidated on mount (default is false). context: https://github.com/TanStack/query/discussions/3121

## How Has This Been Tested?

Locally

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
