### PR TITLE
feat(NON-REQ) Modify DEV cronjob to run at 6pm

### DIFF
--- a/k8s/vista-python-api/overlays/dev/kustomization.yaml
+++ b/k8s/vista-python-api/overlays/dev/kustomization.yaml
@@ -10,6 +10,10 @@ patches:
     target:
       kind: ServiceAccount
       name: vista-python-api-sa
+  - path: patches/cronjob-schedule.yaml
+    target:
+      kind: CronJob
+      name: vista-python-api-refresh-data
 
 labels:
   - pairs:

--- a/k8s/vista-python-api/overlays/dev/patches/cronjob-schedule.yaml
+++ b/k8s/vista-python-api/overlays/dev/patches/cronjob-schedule.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vista-python-api-refresh-data
+spec:
+  schedule: "0 18 * * *"


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
Since schedule is being re-enabled to turn k8s nodes off in DEV between 8pm and 8am weekdays, cronjob schedule for dev has been amended from 2am to 6pm - 2am has been retained for Staging and Production.

## Description
As above

## How Has This Been Tested?
Verified kustomize build, but needs deploying

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
