### PR TITLE
bugfix(NON-REQ): invalid scenarioAssets query when exposure layers changes

### DIFF
--- a/frontend/src/components/map-v2/panels/ExposureView.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.tsx
@@ -243,6 +243,7 @@ const ExposureView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSel
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['exposureLayers', scenarioId] });
             queryClient.invalidateQueries({ queryKey: ['asset-score', scenarioId] });
+            queryClient.invalidateQueries({ queryKey: ['scenarioAssets', scenarioId] });
         },
         onError: () => {
             setMutationError('Failed to update exposure layer visibility');


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context


This is needed incase the score filtering changes, otherwise it could show the wrong assets


## Description

Invalidate scenarioAssets query when toggling exposure layers.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Locally

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
