### PR TITLE
bugfix(DPAV-2220): fix loading spinner getting stuck after focus area…

### DIFF
--- a/frontend/audit-ci.jsonc
+++ b/frontend/audit-ci.jsonc
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
     "low": true,
-    "allowlist": []
+    "allowlist": [],
 }

--- a/frontend/src/components/map-v2/MapLoadingOverlay.tsx
+++ b/frontend/src/components/map-v2/MapLoadingOverlay.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect, useRef } from 'react';
+import { Box, CircularProgress } from '@mui/material';
+import { useDrawingContext } from './context/DrawingContext';
+
+type MapLoadingOverlayProps = {
+    readonly isAssetsFetching: boolean;
+    readonly isSpritesGenerating: boolean;
+    readonly isFocusAreasFetching: boolean;
+    readonly isExposureLayersFetching: boolean;
+};
+
+const MapLoadingOverlay = ({ isAssetsFetching, isSpritesGenerating, isFocusAreasFetching, isExposureLayersFetching }: MapLoadingOverlayProps) => {
+    const { drawingSyncComplete, mapRef, mapReady } = useDrawingContext();
+    const [waitingForMapIdle, setWaitingForMapIdle] = useState(false);
+    const wasDataLoadingRef = useRef(false);
+
+    const isDataLoading = isAssetsFetching || isSpritesGenerating || isFocusAreasFetching || isExposureLayersFetching || !drawingSyncComplete;
+
+    useEffect(() => {
+        if (wasDataLoadingRef.current && !isDataLoading) {
+            setWaitingForMapIdle(true);
+        }
+        wasDataLoadingRef.current = isDataLoading;
+    }, [isDataLoading]);
+
+    useEffect(() => {
+        if (!waitingForMapIdle || !mapReady || !mapRef.current) {
+            return;
+        }
+
+        const map = mapRef.current.getMap();
+        if (!map) {
+            setWaitingForMapIdle(false);
+            return;
+        }
+
+        let completed = false;
+
+        const handleIdle = () => {
+            complete();
+        };
+
+        // Avoid the spinning forever if the map never becomes idle.
+        const timeoutId = setTimeout(() => {
+            complete();
+        }, 3000);
+
+        const complete = () => {
+            if (completed) {
+                return;
+            }
+            completed = true;
+            clearTimeout(timeoutId);
+            map.off('idle', handleIdle);
+            setWaitingForMapIdle(false);
+        };
+
+        // Attach listener first, then check if already idle
+        // This order prevents the race condition where idle fires between check and attach
+        map.on('idle', handleIdle);
+
+        const isAlreadyIdle =
+            (typeof map.areTilesLoaded === 'function' ? map.areTilesLoaded() : true) &&
+            (typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : true) &&
+            (typeof map.isMoving === 'function' ? !map.isMoving() : true);
+
+        if (isAlreadyIdle) {
+            complete();
+        }
+
+        return () => {
+            complete();
+        };
+    }, [waitingForMapIdle, mapRef, mapReady]);
+
+    const isLoading = isDataLoading || waitingForMapIdle;
+
+    return (
+        <Box
+            sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: 'rgba(255, 255, 255, 0.5)',
+                zIndex: 10,
+                opacity: isLoading ? 1 : 0,
+                pointerEvents: isLoading ? 'auto' : 'none',
+                transition: 'opacity 200ms ease-out',
+            }}
+        >
+            <CircularProgress size={48} />
+        </Box>
+    );
+};
+
+export default MapLoadingOverlay;

--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState, useEffect, type ComponentProps } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box } from '@mui/material';
 import type { MapRef, ViewStateChangeEvent } from 'react-map-gl/maplibre';
 import type { MapMouseEvent } from 'maplibre-gl';
 import Map, { Marker } from 'react-map-gl/maplibre';
@@ -20,6 +20,7 @@ import FocusAreaOutline from './FocusAreaOutline';
 import InactiveFocusAreas from './InactiveFocusAreas';
 import ActiveFocusAreas from './ActiveFocusAreas';
 import ConnectedAssetsLayer from './ConnectedAssetsLayer';
+import MapLoadingOverlay from './MapLoadingOverlay';
 import { DrawingProvider, useDrawingContext } from './context/DrawingContext';
 import { usePreloadAssetIcons } from './hooks/usePreloadAssetIcons';
 import { useAssetTypeIcons } from '@/hooks/useAssetTypeIcons';
@@ -34,85 +35,6 @@ import { useRoadRouteLazyQuery, type RoadRouteInputParams } from '@/api/utilitie
 import type { Asset } from '@/api/assets-by-type';
 
 const ASSET_LAYER_IDS = [ASSET_SYMBOL_LAYER_ID, `${ASSET_SYMBOL_LAYER_ID}-selected`, 'map-v2-asset-line-layer'] as const;
-
-type MapLoadingOverlayProps = {
-    readonly isAssetsFetching: boolean;
-    readonly isSpritesGenerating: boolean;
-    readonly isFocusAreasFetching: boolean;
-    readonly isExposureLayersFetching: boolean;
-};
-
-const MapLoadingOverlay = ({ isAssetsFetching, isSpritesGenerating, isFocusAreasFetching, isExposureLayersFetching }: MapLoadingOverlayProps) => {
-    const { drawingSyncComplete, mapRef, mapReady } = useDrawingContext();
-    const [waitingForMapIdle, setWaitingForMapIdle] = useState(false);
-    const wasDataLoadingRef = useRef(false);
-
-    const isDataLoading = isAssetsFetching || isSpritesGenerating || isFocusAreasFetching || isExposureLayersFetching || !drawingSyncComplete;
-
-    useEffect(() => {
-        if (wasDataLoadingRef.current && !isDataLoading) {
-            setWaitingForMapIdle(true);
-        }
-        wasDataLoadingRef.current = isDataLoading;
-    }, [isDataLoading]);
-
-    useEffect(() => {
-        if (!waitingForMapIdle || !mapReady || !mapRef.current) {
-            return;
-        }
-
-        const map = mapRef.current.getMap();
-        if (!map) {
-            setWaitingForMapIdle(false);
-            return;
-        }
-
-        const handleIdle = () => {
-            setWaitingForMapIdle(false);
-            map.off('idle', handleIdle);
-        };
-
-        const tilesLoaded = typeof map.areTilesLoaded === 'function' ? map.areTilesLoaded() : true;
-        const styleLoaded = typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : true;
-        const isMoving = typeof map.isMoving === 'function' ? map.isMoving() : false;
-        if (tilesLoaded && styleLoaded && !isMoving) {
-            const frameId = requestAnimationFrame(() => {
-                setWaitingForMapIdle(false);
-            });
-            return () => cancelAnimationFrame(frameId);
-        }
-
-        map.on('idle', handleIdle);
-
-        return () => {
-            map.off('idle', handleIdle);
-        };
-    }, [waitingForMapIdle, mapRef, mapReady]);
-
-    const isLoading = isDataLoading || waitingForMapIdle;
-
-    return (
-        <Box
-            sx={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                backgroundColor: 'rgba(255, 255, 255, 0.5)',
-                zIndex: 10,
-                opacity: isLoading ? 1 : 0,
-                pointerEvents: isLoading ? 'auto' : 'none',
-                transition: 'opacity 200ms ease-out',
-            }}
-        >
-            <CircularProgress size={48} />
-        </Box>
-    );
-};
 
 type DrawingAwareAssetLayersProps = Omit<ComponentProps<typeof AssetLayers>, 'interactionDisabled'>;
 

--- a/frontend/src/components/map-v2/context/DrawingContext.tsx
+++ b/frontend/src/components/map-v2/context/DrawingContext.tsx
@@ -92,7 +92,6 @@ export const DrawingProvider = ({ children, mapRef, mapReady, scenarioId }: Draw
         }
 
         const draw = drawRef.current;
-        const map = mapRef.current?.getMap();
 
         if (!drawingConfig) {
             loadedEntityIdsRef.current.forEach((id) => {
@@ -157,15 +156,13 @@ export const DrawingProvider = ({ children, mapRef, mapReady, scenarioId }: Draw
             }
         });
 
-        if (changedAny && map) {
-            const handleIdle = () => {
+        if (changedAny) {
+            const frameId = requestAnimationFrame(() => {
                 setDrawingSyncComplete(true);
-                map.off('idle', handleIdle);
-            };
-            map.on('idle', handleIdle);
+            });
 
             return () => {
-                map.off('idle', handleIdle);
+                cancelAnimationFrame(frameId);
             };
         } else {
             setDrawingSyncComplete(true);


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-2220?focusedCommentId=16199

## Description

- Fix race condition where map idle event was missed if map was already idle
- Extract MapLoadingOverlay into separate component
- Simplify DrawingContext to use requestAnimationFrame instead of idle event
- Add 3s timeout fallback to prevent spinner from getting stuck indefinitely

## How Has This Been Tested?

Locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
