### PR TITLE
feat(DPAV-2284): disable asset toggle when area inactive

### DIFF
--- a/frontend/src/components/map-v2/panels/AssetsView.test.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.test.tsx
@@ -909,4 +909,118 @@ describe('AssetsView', () => {
             });
         });
     });
+
+    describe('Disabled state when focus area is inactive', () => {
+        it('disables toggles when selected focus area is not active', async () => {
+            setupMocks({
+                focusAreas: [
+                    {
+                        id: 'focus-area-1',
+                        name: 'Area 1',
+                        geometry: { type: 'Point', coordinates: [0, 0] },
+                        filterMode: 'by_asset_type',
+                        isActive: false,
+                        isSystem: false,
+                    },
+                ],
+                assetCategories: [
+                    {
+                        id: 'cat1',
+                        name: 'Built infrastructure',
+                        subCategories: [
+                            {
+                                id: 'subcat1',
+                                name: 'Utility infrastructure',
+                                assetTypes: [
+                                    {
+                                        id: 'asset-1',
+                                        name: 'Hospital',
+                                        assetCountInFocusArea: 25,
+                                        filteredAssetCount: 25,
+                                        isActive: true,
+                                        datasourceId: 'ds-1',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId="focus-area-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Utility infrastructure')).toBeInTheDocument();
+            });
+
+            const subCategoryHeader = screen.getByText('Utility infrastructure');
+            fireEvent.click(subCategoryHeader);
+
+            await waitFor(() => {
+                const toggleButton = screen.getByLabelText('Hide all Utility infrastructure');
+                expect(toggleButton).toBeDisabled();
+            });
+
+            await waitFor(() => {
+                const assetToggle = screen.getByLabelText('Hide Hospital');
+                expect(assetToggle).toBeDisabled();
+            });
+        });
+
+        it('enables toggles when selected focus area is active', async () => {
+            setupMocks({
+                focusAreas: [
+                    {
+                        id: 'focus-area-1',
+                        name: 'Area 1',
+                        geometry: { type: 'Point', coordinates: [0, 0] },
+                        filterMode: 'by_asset_type',
+                        isActive: true,
+                        isSystem: false,
+                    },
+                ],
+                assetCategories: [
+                    {
+                        id: 'cat1',
+                        name: 'Built infrastructure',
+                        subCategories: [
+                            {
+                                id: 'subcat1',
+                                name: 'Utility infrastructure',
+                                assetTypes: [
+                                    {
+                                        id: 'asset-1',
+                                        name: 'Hospital',
+                                        assetCountInFocusArea: 25,
+                                        filteredAssetCount: 25,
+                                        isActive: true,
+                                        datasourceId: 'ds-1',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            renderWithProviders(<AssetsView {...defaultProps} selectedFocusAreaId="focus-area-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByText('Utility infrastructure')).toBeInTheDocument();
+            });
+
+            const subCategoryHeader = screen.getByText('Utility infrastructure');
+            fireEvent.click(subCategoryHeader);
+
+            await waitFor(() => {
+                const toggleButton = screen.getByLabelText('Hide all Utility infrastructure');
+                expect(toggleButton).not.toBeDisabled();
+            });
+
+            await waitFor(() => {
+                const assetToggle = screen.getByLabelText('Hide Hospital');
+                expect(assetToggle).not.toBeDisabled();
+            });
+        });
+    });
 });

--- a/frontend/src/components/map-v2/panels/AssetsView.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.tsx
@@ -53,6 +53,7 @@ type SubCategoryItemProps = {
     readonly getScoreFilter: (assetTypeId: string) => AssetScoreFilter | undefined;
     readonly isMutating: boolean;
     readonly dataSourceMap: Map<string, DataSource>;
+    readonly disabled?: boolean;
 };
 
 function SubCategoryItem({
@@ -65,7 +66,9 @@ function SubCategoryItem({
     getScoreFilter,
     isMutating,
     dataSourceMap,
+    disabled: externalDisabled = false,
 }: SubCategoryItemProps) {
+    const disabled = isMutating || externalDisabled;
     const activeCount = subCategory.assetTypes.filter((at) => at.isActive).length;
     const totalCount = subCategory.assetTypes.length;
 
@@ -154,14 +157,14 @@ function SubCategoryItem({
                         </Box>
                     )}
                 </Box>
-                <IconToggle state={visibilityState} onChange={handleBulkToggle} disabled={isMutating} aria-label={getToggleAriaLabel()} size="small" />
+                <IconToggle state={visibilityState} onChange={handleBulkToggle} disabled={disabled} aria-label={getToggleAriaLabel()} size="small" />
             </Box>
 
             <Collapse in={isExpanded}>
                 <AssetTypeList
                     assetTypes={subCategory.assetTypes}
                     onToggle={onToggleVisibility}
-                    disabled={isMutating}
+                    disabled={disabled}
                     dataSourceMap={dataSourceMap}
                     onOpenScoreFilter={onOpenScoreFilter}
                     getScoreFilter={getScoreFilter}
@@ -305,6 +308,14 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
             selectedFilterMode,
             onError: setMutationError,
         });
+
+    const isSelectedFocusAreaActive = useMemo(() => {
+        if (!currentFocusAreaId || !focusAreas) {
+            return true;
+        }
+        const selectedFocusArea = focusAreas.find((fa) => fa.id === currentFocusAreaId);
+        return selectedFocusArea?.isActive ?? true;
+    }, [currentFocusAreaId, focusAreas]);
 
     useEffect(() => {
         if (focusAreas) {
@@ -510,7 +521,7 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
                     onApply={handleApplyGlobalScoreFilter}
                     onClear={handleClearGlobalScoreFilter}
                     initialValues={globalScoreFilter}
-                    disabled={isMutating}
+                    disabled={isMutating || !isSelectedFocusAreaActive}
                 />
             );
         }
@@ -561,6 +572,7 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
                                 onOpenScoreFilter={handleOpenScoreFilter}
                                 getScoreFilter={getScoreFilterForAssetType}
                                 isMutating={isMutating}
+                                disabled={!isSelectedFocusAreaActive}
                                 dataSourceMap={dataSourceMap}
                             />
                         ))}

--- a/frontend/src/components/map-v2/panels/ExposureView.test.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.test.tsx
@@ -815,4 +815,126 @@ describe('ExposureView', () => {
             expect(screen.queryByText('Not in area')).not.toBeInTheDocument();
         });
     });
+
+    describe('Disabled state when focus area is inactive', () => {
+        it('disables toggles when selected focus area is not active', async () => {
+            const mockLayersData: ExposureLayersResponse = {
+                featureCollection: {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            id: 'layer-1',
+                            geometry: mockGeometry1,
+                            properties: {
+                                id: 'layer-1',
+                                name: 'Test Layer',
+                                groupName: 'Floods',
+                                groupId: 'floods-group',
+                                isUserDefined: false,
+                            },
+                        },
+                    ],
+                },
+                groups: [
+                    {
+                        id: 'floods-group',
+                        name: 'Floods',
+                        isUserEditable: false,
+                        exposureLayers: [
+                            {
+                                id: 'layer-1',
+                                name: 'Test Layer',
+                                isActive: true,
+                                focusAreaRelation: 'contained',
+                                isUserDefined: false,
+                                geometry: mockGeometry1,
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            mockedFetchFocusAreas.mockResolvedValue([
+                { id: 'fa-1', name: 'Focus Area 1', isActive: false, geometry: mockGeometry1, filterMode: 'by_asset_type', isSystem: false },
+            ]);
+
+            renderWithProviders(<ExposureView {...defaultProps} exposureLayersData={mockLayersData} selectedFocusAreaId="fa-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Floods/)).toBeInTheDocument();
+            });
+
+            const floodsHeader = screen.getByText(/Floods/);
+            const headerButton = floodsHeader.closest('button');
+            if (headerButton) {
+                fireEvent.click(headerButton);
+            }
+
+            await waitFor(() => {
+                const layerToggle = screen.getByLabelText('Hide Test Layer');
+                expect(layerToggle).toBeDisabled();
+            });
+        });
+
+        it('enables toggles when selected focus area is active', async () => {
+            const mockLayersData: ExposureLayersResponse = {
+                featureCollection: {
+                    type: 'FeatureCollection',
+                    features: [
+                        {
+                            type: 'Feature',
+                            id: 'layer-1',
+                            geometry: mockGeometry1,
+                            properties: {
+                                id: 'layer-1',
+                                name: 'Test Layer',
+                                groupName: 'Floods',
+                                groupId: 'floods-group',
+                                isUserDefined: false,
+                            },
+                        },
+                    ],
+                },
+                groups: [
+                    {
+                        id: 'floods-group',
+                        name: 'Floods',
+                        isUserEditable: false,
+                        exposureLayers: [
+                            {
+                                id: 'layer-1',
+                                name: 'Test Layer',
+                                isActive: true,
+                                focusAreaRelation: 'contained',
+                                isUserDefined: false,
+                                geometry: mockGeometry1,
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            mockedFetchFocusAreas.mockResolvedValue([
+                { id: 'fa-1', name: 'Focus Area 1', isActive: true, geometry: mockGeometry1, filterMode: 'by_asset_type', isSystem: false },
+            ]);
+
+            renderWithProviders(<ExposureView {...defaultProps} exposureLayersData={mockLayersData} selectedFocusAreaId="fa-1" />);
+
+            await waitFor(() => {
+                expect(screen.getByText(/Floods/)).toBeInTheDocument();
+            });
+
+            const floodsHeader = screen.getByText(/Floods/);
+            const headerButton = floodsHeader.closest('button');
+            if (headerButton) {
+                fireEvent.click(headerButton);
+            }
+
+            await waitFor(() => {
+                const layerToggle = screen.getByLabelText('Hide Test Layer');
+                expect(layerToggle).not.toBeDisabled();
+            });
+        });
+    });
 });

--- a/frontend/src/components/map-v2/panels/ExposureView.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.tsx
@@ -22,7 +22,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { DeleteOutline, EditNoteOutlined } from '@mui/icons-material';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Feature } from 'geojson';
 
 import { useDrawingContext } from '../context/DrawingContext';
@@ -39,6 +39,7 @@ import {
     type ExposureLayersResponse,
     type FocusAreaRelation,
 } from '@/api/exposure-layers';
+import { fetchFocusAreas } from '@/api/focus-areas';
 import IconToggle from '@/components/IconToggle';
 
 const BADGE_CONFIG: Record<FocusAreaRelation, { label: string; bgColor: string; textColor: string }> = {
@@ -653,6 +654,21 @@ const ExposureView = ({
     const queryClient = useQueryClient();
     const currentFocusAreaId = selectedFocusAreaId ?? null;
 
+    const { data: focusAreas } = useQuery({
+        queryKey: ['focusAreas', scenarioId],
+        queryFn: () => fetchFocusAreas(scenarioId!),
+        enabled: !!scenarioId,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    const isSelectedFocusAreaActive = useMemo(() => {
+        if (!currentFocusAreaId || !focusAreas) {
+            return true;
+        }
+        const selectedFocusArea = focusAreas.find((fa) => fa.id === currentFocusAreaId);
+        return selectedFocusArea?.isActive ?? true;
+    }, [currentFocusAreaId, focusAreas]);
+
     // Extract user-drawn layers for the drawing hook
     const userDrawnLayers = useMemo(() => {
         return exposureLayersData?.groups.flatMap((g) => g.exposureLayers).filter((layer) => layer.isUserDefined && layer.isActive && layer.geometry) ?? [];
@@ -863,6 +879,7 @@ const ExposureView = ({
     }, [exposureLayersData]);
 
     const isMutating = visibilityMutation.isPending || bulkVisibilityMutation.isPending || updateLayerMutation.isPending || deleteLayerMutation.isPending;
+    const disabled = isMutating || !isSelectedFocusAreaActive;
 
     if (!scenarioId) {
         return (
@@ -949,7 +966,7 @@ const ExposureView = ({
                             onToggleGroup={toggleGroup}
                             onToggleLayer={toggleExposureLayer}
                             onBulkToggle={handleBulkToggle}
-                            disabled={isMutating}
+                            disabled={disabled}
                             showBulkToggle={groupData.name === 'Environmentally sensitive areas'}
                         />
                     ))}
@@ -967,7 +984,7 @@ const ExposureView = ({
                             onUpdateLayer={handleUpdateLayer}
                             onDeleteLayer={handleDeleteLayer}
                             onStartDrawing={startDrawing}
-                            disabled={isMutating}
+                            disabled={disabled}
                             isDrawing={isDrawing}
                         />
                     )}


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-2284

## Screenshots (if appropriate):

<img width="1398" height="1156" alt="Screenshot 2026-01-23 at 08 24 46" src="https://github.com/user-attachments/assets/9aeb183b-5ede-478f-b6b2-7562e4b1aebd" />

## Checklist:

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
