### PR TITLE
bugfix(multi): updates to exposure to handle new features

### DIFF
--- a/frontend/src/components/map-v2/MapLoadingOverlay.tsx
+++ b/frontend/src/components/map-v2/MapLoadingOverlay.tsx
@@ -17,55 +17,52 @@ const MapLoadingOverlay = ({ isAssetsFetching, isSpritesGenerating, isFocusAreas
     const isDataLoading = isAssetsFetching || isSpritesGenerating || isFocusAreasFetching || isExposureLayersFetching || !drawingSyncComplete;
 
     useEffect(() => {
-        if (wasDataLoadingRef.current && !isDataLoading) {
+        if (isDataLoading) {
+            setWaitingForMapIdle(false);
+        } else if (wasDataLoadingRef.current) {
             setWaitingForMapIdle(true);
         }
         wasDataLoadingRef.current = isDataLoading;
     }, [isDataLoading]);
 
     useEffect(() => {
-        if (!waitingForMapIdle || !mapReady || !mapRef.current) {
-            return;
-        }
-
-        const map = mapRef.current.getMap();
-        if (!map) {
-            setWaitingForMapIdle(false);
+        if (!waitingForMapIdle) {
             return;
         }
 
         let completed = false;
-
-        const handleIdle = () => {
-            complete();
-        };
-
-        // Avoid the spinning forever if the map never becomes idle.
-        const timeoutId = setTimeout(() => {
-            complete();
-        }, 3000);
-
+        const map = mapReady && mapRef.current ? mapRef.current.getMap() : null;
         const complete = () => {
             if (completed) {
                 return;
             }
             completed = true;
             clearTimeout(timeoutId);
-            map.off('idle', handleIdle);
+            if (map) {
+                map.off('idle', handleIdle);
+            }
             setWaitingForMapIdle(false);
         };
 
-        // Attach listener first, then check if already idle
-        // This order prevents the race condition where idle fires between check and attach
-        map.on('idle', handleIdle);
-
-        const isAlreadyIdle =
-            (typeof map.areTilesLoaded === 'function' ? map.areTilesLoaded() : true) &&
-            (typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : true) &&
-            (typeof map.isMoving === 'function' ? !map.isMoving() : true);
-
-        if (isAlreadyIdle) {
+        const handleIdle = () => {
             complete();
+        };
+
+        const timeoutId = setTimeout(() => {
+            complete();
+        }, 3000);
+
+        if (map) {
+            map.on('idle', handleIdle);
+
+            const isAlreadyIdle =
+                (typeof map.areTilesLoaded === 'function' ? map.areTilesLoaded() : true) &&
+                (typeof map.isStyleLoaded === 'function' ? map.isStyleLoaded() : true) &&
+                (typeof map.isMoving === 'function' ? !map.isMoving() : true);
+
+            if (isAlreadyIdle) {
+                complete();
+            }
         }
 
         return () => {

--- a/frontend/src/components/map-v2/MapView.tsx
+++ b/frontend/src/components/map-v2/MapView.tsx
@@ -91,11 +91,14 @@ const MapView = () => {
     });
 
     const exposureLayersFocusAreaId = useMemo(() => {
+        if (isInExposurePanel) {
+            return selectedFocusAreaId;
+        }
         if (shouldShowAllActiveFocusAreas) {
             return null;
         }
         return selectedFocusAreaId;
-    }, [shouldShowAllActiveFocusAreas, selectedFocusAreaId]);
+    }, [shouldShowAllActiveFocusAreas, selectedFocusAreaId, isInExposurePanel]);
 
     const {
         data: exposureLayersData,

--- a/frontend/src/components/map-v2/panels/ExposureView.test.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.test.tsx
@@ -690,6 +690,44 @@ describe('ExposureView', () => {
                 expect(screen.getByLabelText('Show all')).toBeInTheDocument();
             });
         });
+
+        it('shows partial visibility icon when some layers are visible', async () => {
+            const mixedExposureLayersData = createEnvironmentallySensitiveAreasResponse({
+                layers: [
+                    { id: 'layer-1', name: 'Protected Area 1', isActive: true },
+                    { id: 'layer-2', name: 'Protected Area 2', isActive: false },
+                    { id: 'layer-3', name: 'Protected Area 3', isActive: false },
+                ],
+            });
+            renderWithProviders(<ExposureView {...defaultProps} exposureLayersData={mixedExposureLayersData} selectedFocusAreaId="map-wide-1" />);
+            await waitFor(() => {
+                const toggleButton = screen.getByLabelText('Show all');
+                expect(toggleButton.querySelector('[data-testid="VisibilityOutlinedIcon"]')).toBeInTheDocument();
+            });
+        });
+
+        it('shows filled visibility icon when all layers are visible', async () => {
+            const allActiveExposureLayersData = createEnvironmentallySensitiveAreasResponse({
+                layers: [
+                    { id: 'layer-1', name: 'Protected Area 1', isActive: true },
+                    { id: 'layer-2', name: 'Protected Area 2', isActive: true },
+                    { id: 'layer-3', name: 'Protected Area 3', isActive: true },
+                ],
+            });
+            renderWithProviders(<ExposureView {...defaultProps} exposureLayersData={allActiveExposureLayersData} selectedFocusAreaId="map-wide-1" />);
+            await waitFor(() => {
+                const toggleButton = screen.getByLabelText('Hide all');
+                expect(toggleButton.querySelector('[data-testid="VisibilityIcon"]')).toBeInTheDocument();
+            });
+        });
+
+        it('shows visibility off icon when no layers are visible', async () => {
+            renderWithProviders(<ExposureView {...defaultProps} exposureLayersData={envSensitiveExposureLayersData} selectedFocusAreaId="map-wide-1" />);
+            await waitFor(() => {
+                const toggleButton = screen.getByLabelText('Show all');
+                expect(toggleButton.querySelector('[data-testid="VisibilityOffIcon"]')).toBeInTheDocument();
+            });
+        });
     });
 
     describe('Spatial Relation Badges', () => {
@@ -719,7 +757,7 @@ describe('ExposureView', () => {
             });
         });
 
-        it('displays "Near area" badge for overlapping layers', async () => {
+        it('displays "Partially in area" badge for overlapping layers', async () => {
             const exposureLayersData = createMockExposureLayersResponse({
                 layers: [{ id: 'layer-1', name: 'Overlapping Layer', isActive: false, focusAreaRelation: 'overlaps' }],
             });
@@ -737,7 +775,7 @@ describe('ExposureView', () => {
 
             await waitFor(() => {
                 expect(screen.getByText('Overlapping Layer')).toBeInTheDocument();
-                expect(screen.getByText('Near area')).toBeInTheDocument();
+                expect(screen.getByText('Partially in area')).toBeInTheDocument();
             });
         });
 
@@ -786,7 +824,7 @@ describe('ExposureView', () => {
                 expect(screen.getByText('Inside Layer')).toBeInTheDocument();
                 expect(screen.getByText('Partial Layer')).toBeInTheDocument();
                 expect(screen.getByText('In area')).toBeInTheDocument();
-                expect(screen.getByText('Near area')).toBeInTheDocument();
+                expect(screen.getByText('Partially in area')).toBeInTheDocument();
             });
         });
 
@@ -811,7 +849,7 @@ describe('ExposureView', () => {
             });
 
             expect(screen.queryByText('In area')).not.toBeInTheDocument();
-            expect(screen.queryByText('Near area')).not.toBeInTheDocument();
+            expect(screen.queryByText('Partially in area')).not.toBeInTheDocument();
             expect(screen.queryByText('Not in area')).not.toBeInTheDocument();
         });
     });

--- a/frontend/src/components/map-v2/panels/ExposureView.tsx
+++ b/frontend/src/components/map-v2/panels/ExposureView.tsx
@@ -39,11 +39,11 @@ import {
     type ExposureLayersResponse,
     type FocusAreaRelation,
 } from '@/api/exposure-layers';
-import IconToggle from '@/components/IconToggle';
+import IconToggle, { type VisibilityState } from '@/components/IconToggle';
 
 const BADGE_CONFIG: Record<FocusAreaRelation, { label: string; bgColor: string; textColor: string }> = {
     contained: { label: 'In area', bgColor: '#7eb66d', textColor: '#000' },
-    overlaps: { label: 'Near area', bgColor: '#dfc96e', textColor: '#000' },
+    overlaps: { label: 'Partially in area', bgColor: '#dfc96e', textColor: '#000' },
     elsewhere: { label: 'Not in area', bgColor: '#929292', textColor: '#fff' },
 };
 
@@ -375,17 +375,27 @@ const ExposureGroup = React.memo(
 
         const layerIds = useMemo(() => layers.map(getLayerId).filter((id): id is string => id !== null), [layers]);
 
-        const allLayersVisible = useMemo(() => {
-            return layerIds.length > 0 && layerIds.every((id) => selectedExposureLayerIds[id] === true);
+        const visibilityState: VisibilityState = useMemo(() => {
+            if (layerIds.length === 0) {
+                return 'hidden';
+            }
+            const activeCount = layerIds.filter((id) => selectedExposureLayerIds[id] === true).length;
+            if (activeCount === 0) {
+                return 'hidden';
+            }
+            if (activeCount === layerIds.length) {
+                return 'visible';
+            }
+            return 'partial';
         }, [layerIds, selectedExposureLayerIds]);
 
         const handleToggleAll = useCallback(
             (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => {
                 e.stopPropagation();
                 e.preventDefault();
-                onBulkToggle?.(groupId, !allLayersVisible);
+                onBulkToggle?.(groupId, visibilityState !== 'visible');
             },
-            [groupId, allLayersVisible, onBulkToggle],
+            [groupId, visibilityState, onBulkToggle],
         );
 
         return (
@@ -434,10 +444,10 @@ const ExposureGroup = React.memo(
                     {showBulkToggle && onBulkToggle && layerIds.length > 0 && (
                         <Box sx={{ display: 'flex', alignItems: 'center', px: 2, flexShrink: 0 }}>
                             <IconToggle
-                                checked={allLayersVisible}
+                                state={visibilityState}
                                 onChange={handleToggleAll}
                                 disabled={disabled}
-                                aria-label={allLayersVisible ? 'Hide all' : 'Show all'}
+                                aria-label={visibilityState === 'visible' ? 'Hide all' : 'Show all'}
                                 size="small"
                             />
                         </Box>
@@ -498,17 +508,27 @@ const UserDrawnGroup = React.memo(
             [onToggleGroup, groupName],
         );
 
-        const allLayersVisible = useMemo(() => {
-            return layers.length > 0 && layers.every((layer) => selectedExposureLayerIds[layer.id] === true);
+        const visibilityState: VisibilityState = useMemo(() => {
+            if (layers.length === 0) {
+                return 'hidden';
+            }
+            const activeCount = layers.filter((layer) => selectedExposureLayerIds[layer.id] === true).length;
+            if (activeCount === 0) {
+                return 'hidden';
+            }
+            if (activeCount === layers.length) {
+                return 'visible';
+            }
+            return 'partial';
         }, [layers, selectedExposureLayerIds]);
 
         const handleToggleAll = useCallback(
             (e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>) => {
                 e.stopPropagation();
                 e.preventDefault();
-                onBulkToggle?.(groupId, !allLayersVisible);
+                onBulkToggle?.(groupId, visibilityState !== 'visible');
             },
-            [groupId, allLayersVisible, onBulkToggle],
+            [groupId, visibilityState, onBulkToggle],
         );
 
         const handleDrawMenuClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -571,10 +591,10 @@ const UserDrawnGroup = React.memo(
                     {layers.length > 0 && onBulkToggle && (
                         <Box sx={{ display: 'flex', alignItems: 'center', px: 2, flexShrink: 0 }}>
                             <IconToggle
-                                checked={allLayersVisible}
+                                state={visibilityState}
                                 onChange={handleToggleAll}
                                 disabled={disabled}
-                                aria-label={allLayersVisible ? 'Hide all' : 'Show all'}
+                                aria-label={visibilityState === 'visible' ? 'Hide all' : 'Show all'}
                                 size="small"
                             />
                         </Box>


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

There have been a few different features worked on concurrently which conflict with how they behave, this brings makes this work together by scoping the request to the selected focus area when in the exposure panel so the spatial relations are calculated properly and uses new states.

https://ndtp.atlassian.net/browse/DPAV-2277
https://ndtp.atlassian.net/browse/DPAV-2280

## Description

- Bugfix in race for loading spinner
- Scope exposure layer requests to selected focus area id for spatial FocusAreaRelation
- Rename Near area -> Partially in area
- Update Exposure layer toggles to use new tri-state partial visibility


## How Has This Been Tested?

Locally/unit tests

## Screenshots (if appropriate):
<img width="1952" height="687" alt="Screenshot 2026-01-26 at 11 13 18" src="https://github.com/user-attachments/assets/b52601f2-7231-4a58-b4ad-95a66b7e93a1" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
