### PR TITLE
bugfix: [DPAV-2276] tie pill colour to number of assets in focus area

### DIFF
--- a/frontend/src/components/map-v2/panels/AssetsView.tsx
+++ b/frontend/src/components/map-v2/panels/AssetsView.tsx
@@ -623,7 +623,7 @@ const AssetsView = ({ onClose, scenarioId, selectedFocusAreaId, onFocusAreaSelec
                     <FocusAreaSelector
                         scenarioId={scenarioId}
                         selectedFocusAreaId={currentFocusAreaId}
-                        onFocusAreaSelect={onFocusAreaSelect ?? (() => { })}
+                        onFocusAreaSelect={onFocusAreaSelect ?? (() => {})}
                         label="Select focus area"
                     />
                 </Box>


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Following BA testing, alter the pill colour logic to be driven by the number of assets in that area rather than whether the asset type is toggled on. e.g. if there are 1 or more assets for that type in the area, then it should be green, otherwise it should be grey.

## Description

Update status pill `isActive` function to be determined based on `assetCountInFocusArea` number.

<!--- Describe your changes in detail -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
