### PR TITLE
feat(DPAV-2300): add road network routing with constraint integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ populate-data:
 	cd backend && direnv exec . poetry run python vista-python-api/src/manage.py refresh_data
 	cd backend && direnv exec . poetry run python vista-python-api/src/manage.py refresh_dependency_data
 	cd backend && direnv exec . poetry run python vista-python-api/src/manage.py load_exposure_layers
+	cd backend && direnv exec . poetry run python vista-python-api/src/manage.py refresh_road_network
 
 lint-backend:
 	cd backend && direnv exec . poetry run ruff format .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -151,6 +151,7 @@ indent-style = "space"
 "osmnx.py" = ["N803"]             # Let me call my graph big G.
 "resolvers.py" = ["N803", "N806"]
 "routing.py" = ["N803", "N806"]
+"**/routing/*.py" = ["N803", "N806"]
 "**/tests/**/*.py" = ["F401", "D102", "PLR2004"]
 
 ##############

--- a/backend/vista-python-api/src/api/management/commands/refresh_road_network.py
+++ b/backend/vista-python-api/src/api/management/commands/refresh_road_network.py
@@ -1,0 +1,156 @@
+"""Command to refresh road network data from OS NGD."""
+
+import asyncio
+import logging
+import time
+
+from asgiref.sync import async_to_sync
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from api.models.road_link import RoadLink
+from api.repository.external.asset_data_source_handlers.base import DataSourceHandler
+from api.repository.external.road_link_mapper import RoadLinkMapper
+
+ISLE_OF_WIGHT_BBOX = "-1.585464,50.562959,-0.926285,50.761219"
+OS_NGD_BASE_URL = "https://api.os.uk/features/ngd/ofa/v1/collections"
+ROAD_LINK_COLLECTION = "trn-ntwk-roadlink-4"
+SPEED_COLLECTION = "trn-rami-averageandindicativespeed-1"
+
+PAGE_SIZE = 100
+PAGES_PER_WORKER = 10  # Each worker fetches 1000 features
+NUM_WORKERS = 5
+
+
+class RoadNetworkHandler(DataSourceHandler):
+    """Handler for fetching road network data from OS NGD."""
+
+    def __init__(self):
+        """Construct instance with Isle of Wight bbox."""
+        super().__init__(ISLE_OF_WIGHT_BBOX)
+        self.logger = logging.getLogger(__name__)
+
+    async def fetch_all_from_collection(self, collection: str) -> list[dict]:
+        """Fetch all features from a collection with concurrent workers."""
+        url = (
+            f"{OS_NGD_BASE_URL}/{collection}/items"
+            f"?key={settings.OS_NGD_API_KEY}&bbox={self.locator}"
+        )
+        return await self._fetch_paginated(url, collection)
+
+    async def _fetch_paginated(self, base_url: str, collection: str) -> list[dict]:
+        """Paginate through all results for a given base URL.
+
+        Workers fetch chunks in parallel (0-1k, 1k-2k, etc).
+        After each round, check if we hit the end and need more.
+        """
+        all_features = []
+        round_start_page = 0
+
+        while True:
+            tasks = []
+            for i in range(NUM_WORKERS):
+                start_page = round_start_page + (i * PAGES_PER_WORKER)
+                tasks.append(self._fetch_page_range(base_url, start_page, PAGES_PER_WORKER))
+
+            results = await asyncio.gather(*tasks)
+
+            hit_end = False
+            for features, worker_hit_end in results:
+                all_features.extend(features)
+                if worker_hit_end:
+                    hit_end = True
+
+            self.logger.info("Fetched %s features so far from %s", len(all_features), collection)
+
+            if hit_end:
+                break
+
+            round_start_page += NUM_WORKERS * PAGES_PER_WORKER
+
+        return all_features
+
+    async def _fetch_page_range(
+        self, base_url: str, start_page: int, num_pages: int
+    ) -> tuple[list[dict], bool]:
+        """Fetch a range of pages sequentially. Returns (features, hit_end)."""
+        features = []
+        for page in range(start_page, start_page + num_pages):
+            offset = page * PAGE_SIZE
+            response = await self.fetch_from_url_with_retry(
+                f"{base_url}&offset={offset}&limit={PAGE_SIZE}"
+            )
+            if not response:
+                return features, True
+
+            page_features = response.get("features", [])
+            features.extend(page_features)
+
+            if len(page_features) < PAGE_SIZE:
+                return features, True
+
+        return features, False
+
+
+class Command(BaseCommand):
+    """Refresh road network data from OS NGD.
+
+    Fetches from two collections:
+    1. trn-ntwk-roadlink-4 - Road geometry, directionality, classification
+    2. trn-rami-averageandindicativespeed-1 - Speed limits (joined by osid)
+
+    Writes data to the RoadLink table.
+    """
+
+    help = "Refresh road network data from OS NGD Road Links and RAMI speed data"
+    logger = logging.getLogger(__name__)
+
+    def handle(self, *_args, **_kwargs):
+        """Fetch road network and save to RoadLink table."""
+        start_time = time.perf_counter()
+        self.logger.info("Starting road network refresh...")
+
+        road_links = async_to_sync(self._fetch_and_build_road_links)()
+        self.logger.info("Fetched %s road links", len(road_links))
+
+        RoadLink.objects.all().delete()
+        RoadLink.objects.bulk_create(road_links, batch_size=1000)
+
+        self.logger.info("Road network refresh complete in %ss", time.perf_counter() - start_time)
+
+    async def _fetch_and_build_road_links(self) -> list[RoadLink]:
+        """Fetch road links and speed data in parallel, then combine them."""
+        handler = RoadNetworkHandler()
+
+        self.logger.info("Fetching road links and speed data in parallel...")
+        road_link_features, speed_features = await asyncio.gather(
+            handler.fetch_all_from_collection(ROAD_LINK_COLLECTION),
+            handler.fetch_all_from_collection(SPEED_COLLECTION),
+        )
+        self.logger.info(
+            "Fetched %s road links and %s speed records",
+            len(road_link_features),
+            len(speed_features),
+        )
+
+        speed_lookup = self._build_speed_lookup(speed_features)
+        self.logger.info("Built speed lookup with %s entries", len(speed_lookup))
+
+        return [
+            RoadLinkMapper.map_from_os_ngd(feature, speed_lookup) for feature in road_link_features
+        ]
+
+    def _build_speed_lookup(self, speed_features: list[dict]) -> dict[str, float]:
+        """Build lookup from road link OSID to speed limit in mph."""
+        lookup = {}
+        for feature in speed_features:
+            props = feature.get("properties", {})
+            osid = props.get("osid")
+            if not osid:
+                continue
+
+            speed_mph = props.get("indicativespeedlimit_mph")
+            if speed_mph:
+                lookup[osid] = float(speed_mph)
+
+        return lookup

--- a/backend/vista-python-api/src/api/migrations/0051_add_road_link.py
+++ b/backend/vista-python-api/src/api/migrations/0051_add_road_link.py
@@ -1,0 +1,140 @@
+"""Add RoadLink model for road network routing."""
+
+import uuid
+from typing import ClassVar
+
+import django.contrib.gis.db.models.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Migration to add RoadLink model."""
+
+    dependencies: ClassVar = [
+        ("api", "0050_group_ordering_and_uniqueness"),
+    ]
+
+    operations: ClassVar = [
+        migrations.CreateModel(
+            name="RoadLink",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("osid", models.CharField(db_index=True, max_length=100, unique=True)),
+                ("geometry", django.contrib.gis.db.models.fields.LineStringField(srid=4326)),
+                ("length_m", models.FloatField()),
+                (
+                    "directionality",
+                    models.CharField(
+                        choices=[
+                            ("Both Directions", "Both Directions"),
+                            ("In Direction", "In Direction"),
+                            ("In Opposite Direction", "In Opposite Direction"),
+                        ],
+                        default="Both Directions",
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "road_classification",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("A Road", "A Road"),
+                            ("B Road", "B Road"),
+                            ("Classified Unnumbered", "Classified Unnumbered"),
+                            ("Motorway", "Motorway"),
+                            ("Not Classified", "Not Classified"),
+                            ("Unclassified", "Unclassified"),
+                            ("Unknown", "Unknown"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "route_hierarchy",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("A Road", "A Road"),
+                            ("A Road Primary", "A Road Primary"),
+                            ("B Road", "B Road"),
+                            ("B Road Primary", "B Road Primary"),
+                            ("Local Access Road", "Local Access Road"),
+                            ("Local Road", "Local Road"),
+                            ("Minor Road", "Minor Road"),
+                            ("Motorway", "Motorway"),
+                            ("Restricted Local Access Road", "Restricted Local Access Road"),
+                            (
+                                "Restricted Secondary Access Road",
+                                "Restricted Secondary Access Road",
+                            ),
+                            ("Secondary Access Road", "Secondary Access Road"),
+                            ("Shared Use Road", "Shared Use Road"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                ("road_number", models.CharField(blank=True, max_length=20, null=True)),
+                (
+                    "form_of_way",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("Canal Path", "Canal Path"),
+                            ("Dual Carriageway", "Dual Carriageway"),
+                            ("Enclosed Traffic Area", "Enclosed Traffic Area"),
+                            ("Footbridge", "Footbridge"),
+                            ("Guided Busway", "Guided Busway"),
+                            ("Layby", "Layby"),
+                            ("Path", "Path"),
+                            ("Path With Ford", "Path With Ford"),
+                            ("Path With Level Crossing", "Path With Level Crossing"),
+                            ("Path With Steps", "Path With Steps"),
+                            ("Roundabout", "Roundabout"),
+                            ("Service Road", "Service Road"),
+                            ("Shared Use Carriageway", "Shared Use Carriageway"),
+                            ("Single Carriageway", "Single Carriageway"),
+                            ("Slip Road", "Slip Road"),
+                            ("Subway", "Subway"),
+                            ("Track", "Track"),
+                            ("Traffic Island Link", "Traffic Island Link"),
+                            ("Traffic Island Link At Junction", "Traffic Island Link At Junction"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "operational_state",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("Addressing Only", "Addressing Only"),
+                            ("Open", "Open"),
+                            ("Permanently Closed", "Permanently Closed"),
+                            ("Prospective", "Prospective"),
+                            ("Temporarily Closed", "Temporarily Closed"),
+                            ("Under Construction", "Under Construction"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                ("trunk_road", models.BooleanField(default=False)),
+                ("primary_route", models.BooleanField(default=False)),
+                ("start_node", models.CharField(blank=True, db_index=True, max_length=100)),
+                ("end_node", models.CharField(blank=True, db_index=True, max_length=100)),
+                ("speed_limit_mph", models.FloatField(blank=True, null=True)),
+                ("name", models.CharField(blank=True, max_length=255)),
+                ("versiondate", models.DateTimeField(blank=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.AddIndex(
+            model_name="roadlink",
+            index=models.Index(fields=["start_node", "end_node"], name="roadlink_node_idx"),
+        ),
+    ]

--- a/backend/vista-python-api/src/api/models/__init__.py
+++ b/backend/vista-python-api/src/api/models/__init__.py
@@ -14,6 +14,14 @@ from .dependency import Dependency
 from .exposure_layer import ExposureLayer, ExposureLayerType
 from .focus_area import FocusArea
 from .group import Group, GroupDataSourceAccess, GroupMembership
+from .road_link import (
+    Directionality,
+    FormOfWay,
+    OperationalState,
+    RoadClassification,
+    RoadLink,
+    RouteHierarchy,
+)
 from .scenario import Scenario
 from .scenario_asset import ScenarioAsset
 from .visible_asset import VisibleAsset
@@ -30,12 +38,18 @@ __all__ = [
     "ConstraintInterventionType",
     "DataSource",
     "Dependency",
+    "Directionality",
     "ExposureLayer",
     "ExposureLayerType",
     "FocusArea",
+    "FormOfWay",
     "Group",
     "GroupDataSourceAccess",
     "GroupMembership",
+    "OperationalState",
+    "RoadClassification",
+    "RoadLink",
+    "RouteHierarchy",
     "Scenario",
     "ScenarioAsset",
     "VisibleAsset",

--- a/backend/vista-python-api/src/api/models/road_link.py
+++ b/backend/vista-python-api/src/api/models/road_link.py
@@ -1,0 +1,166 @@
+"""Road network link model for routing calculations."""
+
+import uuid
+from typing import ClassVar
+
+from django.contrib.gis.db import models
+
+
+class Directionality(models.TextChoices):
+    """Directionality values from OS NGD.
+
+    See: https://docs.os.uk/osngd/code-lists/code-lists-overview/linkdirectionvalue
+    """
+
+    BOTH = "Both Directions"
+    IN_DIRECTION = "In Direction"
+    IN_OPPOSITE = "In Opposite Direction"
+
+
+class RoadClassification(models.TextChoices):
+    """Road classification values from OS NGD.
+
+    See: https://docs.os.uk/osngd/code-lists/code-lists-overview/roadclassificationvalue
+    """
+
+    A_ROAD = "A Road"
+    B_ROAD = "B Road"
+    CLASSIFIED_UNNUMBERED = "Classified Unnumbered"
+    MOTORWAY = "Motorway"
+    NOT_CLASSIFIED = "Not Classified"
+    UNCLASSIFIED = "Unclassified"
+    UNKNOWN = "Unknown"
+
+
+class RouteHierarchy(models.TextChoices):
+    """Route hierarchy/road function values from OS NGD.
+
+    See: https://docs.os.uk/osngd/code-lists/code-lists-overview/roadfunctionvalue
+    """
+
+    A_ROAD = "A Road"
+    A_ROAD_PRIMARY = "A Road Primary"
+    B_ROAD = "B Road"
+    B_ROAD_PRIMARY = "B Road Primary"
+    LOCAL_ACCESS_ROAD = "Local Access Road"
+    LOCAL_ROAD = "Local Road"
+    MINOR_ROAD = "Minor Road"
+    MOTORWAY = "Motorway"
+    RESTRICTED_LOCAL_ACCESS_ROAD = "Restricted Local Access Road"
+    RESTRICTED_SECONDARY_ACCESS_ROAD = "Restricted Secondary Access Road"
+    SECONDARY_ACCESS_ROAD = "Secondary Access Road"
+    SHARED_USE_ROAD = "Shared Use Road"
+
+
+class FormOfWay(models.TextChoices):
+    """Form of way type values from OS NGD.
+
+    See: https://docs.os.uk/osngd/code-lists/code-lists-overview/formofwaytypevalue
+    """
+
+    CANAL_PATH = "Canal Path"
+    DUAL_CARRIAGEWAY = "Dual Carriageway"
+    ENCLOSED_TRAFFIC_AREA = "Enclosed Traffic Area"
+    FOOTBRIDGE = "Footbridge"
+    GUIDED_BUSWAY = "Guided Busway"
+    LAYBY = "Layby"
+    PATH = "Path"
+    PATH_WITH_FORD = "Path With Ford"
+    PATH_WITH_LEVEL_CROSSING = "Path With Level Crossing"
+    PATH_WITH_STEPS = "Path With Steps"
+    ROUNDABOUT = "Roundabout"
+    SERVICE_ROAD = "Service Road"
+    SHARED_USE_CARRIAGEWAY = "Shared Use Carriageway"
+    SINGLE_CARRIAGEWAY = "Single Carriageway"
+    SLIP_ROAD = "Slip Road"
+    SUBWAY = "Subway"
+    TRACK = "Track"
+    TRAFFIC_ISLAND_LINK = "Traffic Island Link"
+    TRAFFIC_ISLAND_LINK_AT_JUNCTION = "Traffic Island Link At Junction"
+
+
+class OperationalState(models.TextChoices):
+    """Operational state values from OS NGD.
+
+    See: https://docs.os.uk/osngd/code-lists/code-lists-overview/operationalstatevalue
+    """
+
+    ADDRESSING_ONLY = "Addressing Only"
+    OPEN = "Open"
+    PERMANENTLY_CLOSED = "Permanently Closed"
+    PROSPECTIVE = "Prospective"
+    TEMPORARILY_CLOSED = "Temporarily Closed"
+    UNDER_CONSTRUCTION = "Under Construction"
+
+
+DEFAULT_SPEEDS_MPH = {
+    RoadClassification.MOTORWAY: 70,
+    RoadClassification.A_ROAD: 60,
+    RoadClassification.B_ROAD: 60,
+    RoadClassification.CLASSIFIED_UNNUMBERED: 30,
+    RoadClassification.NOT_CLASSIFIED: 30,
+    RoadClassification.UNCLASSIFIED: 60,
+    RoadClassification.UNKNOWN: 30,
+}
+
+
+class RoadLink(models.Model):
+    """Road network link for routing calculations.
+
+    Data sourced from OS NGD Road Link collection (trn-ntwk-roadlink-4).
+    Speed limits from RAMI collection (trn-rami-averageandindicativespeed-1).
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    osid = models.CharField(max_length=100, unique=True, db_index=True)
+    geometry = models.LineStringField(srid=4326)
+    length_m = models.FloatField()
+
+    directionality = models.CharField(
+        max_length=50, choices=Directionality.choices, default=Directionality.BOTH
+    )
+
+    road_number = models.CharField(max_length=20, null=True, blank=True)
+
+    road_classification = models.CharField(
+        max_length=50, choices=RoadClassification.choices, blank=True
+    )
+
+    route_hierarchy = models.CharField(max_length=50, choices=RouteHierarchy.choices, blank=True)
+
+    form_of_way = models.CharField(max_length=50, choices=FormOfWay.choices, blank=True)
+
+    operational_state = models.CharField(
+        max_length=50, choices=OperationalState.choices, blank=True
+    )
+
+    trunk_road = models.BooleanField(default=False)
+    primary_route = models.BooleanField(default=False)
+
+    start_node = models.CharField(max_length=100, blank=True, db_index=True)
+    end_node = models.CharField(max_length=100, blank=True, db_index=True)
+
+    speed_limit_mph = models.FloatField(null=True, blank=True)
+
+    name = models.CharField(max_length=255, blank=True)
+    versiondate = models.DateTimeField(null=True, blank=True)
+    last_updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        """Meta configuration."""
+
+        indexes: ClassVar = [
+            models.Index(fields=["start_node", "end_node"], name="roadlink_node_idx"),
+        ]
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        display_name = self.name or self.road_number or self.osid
+        classification = self.road_classification or RoadClassification.UNKNOWN
+        return f"{display_name} ({classification})"
+
+    def get_speed(self) -> float:
+        """Get speed in mph, falling back to default by classification."""
+        if self.speed_limit_mph:
+            return self.speed_limit_mph
+        return DEFAULT_SPEEDS_MPH.get(self.road_classification, 30)

--- a/backend/vista-python-api/src/api/repository/external/road_link_mapper.py
+++ b/backend/vista-python-api/src/api/repository/external/road_link_mapper.py
@@ -1,0 +1,61 @@
+"""Mapper for OS NGD Road Link features to RoadLink model instances."""
+
+from datetime import UTC, datetime
+from json import dumps
+
+from django.contrib.gis.geos import GEOSGeometry
+
+from api.models.road_link import Directionality, RoadLink
+
+
+class RoadLinkMapper:
+    """Maps OS NGD Road Link features to RoadLink model instances."""
+
+    @staticmethod
+    def map_from_os_ngd(feature: dict, speed_lookup: dict[str, float] | None = None) -> RoadLink:
+        """Map a Road Link feature to RoadLink model.
+
+        Args:
+            feature: GeoJSON feature from trn-ntwk-roadlink-4
+            speed_lookup: Dict mapping road link OSID to speed_limit_mph (from RAMI)
+
+        Returns:
+            RoadLink model instance
+        """
+        props = feature.get("properties", {})
+        osid = feature.get("id", "")
+
+        speed_limit = None
+        if speed_lookup and osid in speed_lookup:
+            speed_limit = speed_lookup[osid]
+
+        road_number = props.get("roadclassificationnumber")
+        name = props.get("name1_text") or road_number or osid
+
+        versiondate = RoadLinkMapper._parse_versiondate(props.get("versiondate"))
+
+        return RoadLink(
+            osid=osid,
+            geometry=GEOSGeometry(dumps(feature["geometry"])),
+            length_m=props.get("geometry_length_m", 0),
+            directionality=props.get("directionality", Directionality.BOTH),
+            road_classification=props.get("roadclassification") or "",
+            route_hierarchy=props.get("routehierarchy") or "",
+            road_number=road_number,
+            form_of_way=props.get("description") or "",
+            operational_state=props.get("operationalstate") or "",
+            trunk_road=props.get("trunkroad", False),
+            primary_route=props.get("primaryroute", False),
+            start_node=props.get("startnode") or "",
+            end_node=props.get("endnode") or "",
+            name=name,
+            speed_limit_mph=speed_limit,
+            versiondate=versiondate,
+        )
+
+    @staticmethod
+    def _parse_versiondate(value: str | None) -> datetime | None:
+        """Parse a versiondate string from OS NGD into a datetime."""
+        if not value:
+            return None
+        return datetime.fromisoformat(value).replace(tzinfo=UTC)

--- a/backend/vista-python-api/src/api/routing/__init__.py
+++ b/backend/vista-python-api/src/api/routing/__init__.py
@@ -1,0 +1,12 @@
+"""Routing module for road network path calculations."""
+
+from .constraint_provider import ConstraintProvider
+from .graph_cache import routing_cache
+from .route_calculator import RouteCalculator, RoutePoint
+
+__all__ = [
+    "ConstraintProvider",
+    "RouteCalculator",
+    "RoutePoint",
+    "routing_cache",
+]

--- a/backend/vista-python-api/src/api/routing/constraint_provider.py
+++ b/backend/vista-python-api/src/api/routing/constraint_provider.py
@@ -1,0 +1,122 @@
+"""Database-backed constraint provider."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.contrib.gis.db.models import GeometryField
+from django.db.models.expressions import RawSQL
+from shapely import make_valid, wkb
+
+from api.models import Asset, ConstraintIntervention, ExposureLayer, FocusArea, VisibleExposureLayer
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from shapely.geometry.base import BaseGeometry
+
+logger = logging.getLogger(__name__)
+
+BUFFER_METERS = 10
+
+
+class ConstraintProvider:
+    """Fetches routing constraint geometries."""
+
+    @staticmethod
+    def _to_shapely(geom_field) -> BaseGeometry:
+        """Convert a Django GIS geometry field to a valid Shapely geometry."""
+        return make_valid(wkb.loads(bytes(geom_field.wkb)))
+
+    def get_blocked_geometries(
+        self,
+        scenario_id: UUID | None = None,
+        user_id: UUID | None = None,
+        vehicle: str | None = None,
+    ) -> list[BaseGeometry]:
+        """Get all geometries that should block routing."""
+        geometries: list[BaseGeometry] = []
+
+        if scenario_id and user_id:
+            geometries.extend(self._get_constraint_geometries(scenario_id, user_id))
+            geometries.extend(self._get_flood_geometries(scenario_id, user_id))
+
+        if vehicle:
+            geometries.extend(self._get_bridge_geometries(vehicle))
+
+        return geometries
+
+    def _get_constraint_geometries(
+        self,
+        scenario_id: UUID,
+        user_id: UUID,
+    ) -> list[BaseGeometry]:
+        """Get geometries from constraint interventions.
+
+        LineStrings are buffered by BUFFER_METERS in the query; polygons are returned as-is.
+        """
+        constraints = ConstraintIntervention.objects.filter(
+            scenario_id=scenario_id,
+            user_id=user_id,
+            is_active=True,
+            type__impacts_routing=True,
+        ).annotate(
+            routing_geom=RawSQL(
+                """
+                CASE ST_GeometryType(geometry)
+                    WHEN 'ST_LineString'
+                        THEN ST_Buffer(geometry::geography, %s)::geometry
+                    ELSE geometry
+                END
+                """,
+                [BUFFER_METERS],
+                output_field=GeometryField(),
+            ),
+        )
+
+        return [self._to_shapely(c.routing_geom) for c in constraints]
+
+    def _get_flood_geometries(
+        self,
+        scenario_id: UUID,
+        user_id: UUID,
+    ) -> list[BaseGeometry]:
+        """Get geometries from visible flood exposure layers."""
+        focus_area_ids = FocusArea.objects.filter(
+            scenario_id=scenario_id,
+            user_id=user_id,
+            is_active=True,
+        ).values_list("id", flat=True)
+
+        if not focus_area_ids:
+            return []
+
+        visible_layer_ids = VisibleExposureLayer.objects.filter(
+            focus_area_id__in=focus_area_ids
+        ).values_list("exposure_layer_id", flat=True)
+
+        if not visible_layer_ids:
+            return []
+
+        flood_layers = ExposureLayer.objects.filter(
+            id__in=visible_layer_ids,
+            type__name="Floods",
+        ).only("geometry")
+
+        return [self._to_shapely(layer.geometry) for layer in flood_layers]
+
+    def _get_bridge_geometries(self, vehicle: str) -> list[BaseGeometry]:
+        """Get buffered geometries for low bridges (HGV only)."""
+        if vehicle != "HGV":
+            return []
+
+        bridges = Asset.objects.filter(type__name="Low bridge").annotate(
+            buffered_geom=RawSQL(
+                "ST_Buffer(geom::geography, %s)::geometry",
+                [BUFFER_METERS],
+                output_field=GeometryField(),
+            ),
+        )
+
+        return [self._to_shapely(bridge.buffered_geom) for bridge in bridges]

--- a/backend/vista-python-api/src/api/routing/graph_builder.py
+++ b/backend/vista-python-api/src/api/routing/graph_builder.py
@@ -1,0 +1,125 @@
+"""Build NetworkX routing graph from RoadLink database."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+import networkx as nx
+from django.db.models import Count, Max
+from shapely import STRtree
+from shapely.geometry import LineString
+
+from api.models.road_link import Directionality, OperationalState, RoadLink
+
+if TYPE_CHECKING:
+    from networkx import DiGraph
+
+logger = logging.getLogger(__name__)
+
+MPH_TO_MPS = 0.44704  # miles per hour to meters per second
+
+
+def build_graph_from_database() -> DiGraph:
+    """Build a NetworkX DiGraph from RoadLink records.
+
+    Returns:
+        NetworkX DiGraph with road network topology.
+        Nodes are identified by OS NGD node IDs (start_node/end_node).
+        Edges have attributes: osid, geometry, length_m, speed_mps, travel_time_s
+    """
+    G = nx.DiGraph()
+
+    road_links = RoadLink.objects.all().only(
+        "osid",
+        "geometry",
+        "length_m",
+        "directionality",
+        "start_node",
+        "end_node",
+        "speed_limit_mph",
+        "road_classification",
+        "operational_state",
+        "name",
+    )
+
+    for link in road_links:
+        if not link.start_node or not link.end_node:
+            continue
+
+        if link.operational_state and link.operational_state != OperationalState.OPEN:
+            continue
+
+        coords = link.geometry.coords
+        start_coords = coords[0]  # (lon, lat)
+        end_coords = coords[-1]
+
+        if link.start_node not in G:
+            G.add_node(link.start_node, x=start_coords[0], y=start_coords[1])
+        if link.end_node not in G:
+            G.add_node(link.end_node, x=end_coords[0], y=end_coords[1])
+
+        speed_mph = link.get_speed()
+        speed_mps = speed_mph * MPH_TO_MPS
+        travel_time_s = link.length_m / speed_mps if speed_mps > 0 else float("inf")
+
+        edge_attrs = {
+            "osid": link.osid,
+            "geometry": LineString(link.geometry.coords),
+            "length_m": link.length_m,
+            "speed_mps": speed_mps,
+            "travel_time_s": travel_time_s,
+            "name": link.name or "",
+        }
+
+        if link.directionality == Directionality.BOTH:
+            G.add_edge(link.start_node, link.end_node, **edge_attrs)
+            G.add_edge(link.end_node, link.start_node, **edge_attrs)
+        elif link.directionality == Directionality.IN_DIRECTION:
+            G.add_edge(link.start_node, link.end_node, **edge_attrs)
+        elif link.directionality == Directionality.IN_OPPOSITE:
+            G.add_edge(link.end_node, link.start_node, **edge_attrs)
+
+    logger.info("Built graph with %d nodes and %d edges", G.number_of_nodes(), G.number_of_edges())
+    return G
+
+
+def compute_data_hash() -> str:
+    """Compute hash of RoadLink data for change detection.
+
+    Returns:
+        MD5 hash string based on record count and latest update timestamp.
+    """
+    agg = RoadLink.objects.aggregate(count=Count("id"), latest=Max("last_updated"))
+    count = agg["count"]
+    latest = agg["latest"]
+    latest_ts = latest.isoformat() if latest else ""
+
+    hash_input = f"{count}:{latest_ts}"
+    return hashlib.md5(hash_input.encode(), usedforsecurity=False).hexdigest()
+
+
+def build_edge_index(G: DiGraph) -> tuple[STRtree | None, list, list]:
+    """Build spatial index of edge geometries for fast intersection queries.
+
+    Args:
+        G: NetworkX graph with edge geometries
+
+    Returns:
+        Tuple of (STRtree, edge_keys, edge_geometries) or (None, [], []) if no edges.
+    """
+    edge_geoms = []
+    edge_keys = []
+
+    for u, v, data in G.edges(data=True):
+        geom = data.get("geometry")
+        if geom:
+            edge_geoms.append(geom)
+            edge_keys.append((u, v))
+
+    if not edge_geoms:
+        return None, [], []
+
+    logger.info("Built edge spatial index with %d geometries", len(edge_geoms))
+    return STRtree(edge_geoms), edge_keys, edge_geoms

--- a/backend/vista-python-api/src/api/routing/graph_cache.py
+++ b/backend/vista-python-api/src/api/routing/graph_cache.py
@@ -1,0 +1,91 @@
+"""Thread-safe graph cache management."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+from .graph_builder import build_edge_index, build_graph_from_database, compute_data_hash
+from .refresh_scheduler import RefreshScheduler
+
+if TYPE_CHECKING:
+    from networkx import DiGraph
+    from shapely import STRtree
+    from shapely.geometry import LineString
+
+logger = logging.getLogger(__name__)
+
+
+class RoutingCache:
+    """Thread-safe cache for the routing graph."""
+
+    def __init__(self) -> None:
+        """Initialize the routing cache."""
+        self._lock = threading.RLock()
+        self._graph: DiGraph | None = None
+        self._edge_index: STRtree | None = None
+        self._edge_keys: list[tuple[str, str]] = []
+        self._edge_geometries: list[LineString] = []
+        self._data_hash: str = ""
+        self._scheduler: RefreshScheduler | None = None
+
+    def get_graph(self) -> DiGraph:
+        """Get the cached routing graph, initializing lazily if needed."""
+        with self._lock:
+            if self._graph is None:
+                logger.info("Routing cache accessed before initialization, building graph...")
+                self._build()
+            return self._graph
+
+    def get_edge_index(self) -> tuple[STRtree | None, list, list]:
+        """Get the spatial index of edge geometries, initializing lazily if needed."""
+        with self._lock:
+            if self._graph is None:
+                logger.info("Edge index accessed before initialization, building...")
+                self._build()
+            return self._edge_index, self._edge_keys, self._edge_geometries
+
+    def initialize(self) -> None:
+        """Initialize the cache and start background refresh. Call once at startup."""
+        with self._lock:
+            logger.info("Initializing routing cache...")
+            self._build()
+            self._scheduler = RefreshScheduler(
+                has_changed_fn=self._has_data_changed,
+                rebuild_fn=self._thread_safe_rebuild,
+            )
+            self._scheduler.start()
+
+    def invalidate(self) -> None:
+        """Force cache rebuild from database."""
+        with self._lock:
+            logger.info("Rebuilding routing cache...")
+            self._build()
+
+    def shutdown(self) -> None:
+        """Stop the background refresh scheduler."""
+        if self._scheduler:
+            self._scheduler.stop()
+            self._scheduler = None
+
+    def _build(self) -> None:
+        """Build the graph cache from database."""
+        self._graph = build_graph_from_database()
+        self._edge_index, self._edge_keys, self._edge_geometries = build_edge_index(self._graph)
+        self._data_hash = compute_data_hash()
+        logger.info(
+            "Routing cache built: %d nodes, %d edges",
+            self._graph.number_of_nodes(),
+            self._graph.number_of_edges(),
+        )
+
+    def _has_data_changed(self) -> bool:
+        return compute_data_hash() != self._data_hash
+
+    def _thread_safe_rebuild(self) -> None:
+        with self._lock:
+            self._build()
+
+
+routing_cache = RoutingCache()

--- a/backend/vista-python-api/src/api/routing/refresh_scheduler.py
+++ b/backend/vista-python-api/src/api/routing/refresh_scheduler.py
@@ -1,0 +1,64 @@
+"""Background refresh scheduler for routing cache."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+REFRESH_INTERVAL_SECONDS = 300
+
+
+class RefreshScheduler:
+    """Periodically checks for data changes and triggers a rebuild callback."""
+
+    def __init__(
+        self,
+        has_changed_fn: Callable[[], bool],
+        rebuild_fn: Callable[[], None],
+        interval: float = REFRESH_INTERVAL_SECONDS,
+    ) -> None:
+        """Initialize the scheduler with change detection and rebuild callbacks."""
+        self._has_changed = has_changed_fn
+        self._rebuild = rebuild_fn
+        self._interval = interval
+        self._thread: threading.Thread | None = None
+        self._shutdown = threading.Event()
+
+    def start(self) -> None:
+        """Start the background refresh thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._shutdown.clear()
+        self._thread = threading.Thread(
+            target=self._loop,
+            daemon=True,
+            name="routing-cache-refresh",
+        )
+        self._thread.start()
+        logger.info("Started routing cache refresh scheduler")
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Stop the background refresh thread."""
+        self._shutdown.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=timeout)
+        self._thread = None
+
+    def _loop(self) -> None:
+        """Background loop that checks for changes and rebuilds."""
+        while not self._shutdown.is_set():
+            self._shutdown.wait(timeout=self._interval)
+            if self._shutdown.is_set():
+                break
+            try:
+                if self._has_changed():
+                    logger.info("Road network data changed, rebuilding cache...")
+                    self._rebuild()
+            except Exception:
+                logger.exception("Error during cache refresh")

--- a/backend/vista-python-api/src/api/routing/route_calculator.py
+++ b/backend/vista-python-api/src/api/routing/route_calculator.py
@@ -1,0 +1,897 @@
+"""Route calculation with constraint integration.
+
+This module handles routing between two points on the road network, with support for:
+- Edge snapping (projecting click points onto nearest road geometry)
+- Constraint-based edge blocking (road closures, floods, HGV restrictions)
+- Accurate geometry trimming for mid-segment start/end points
+
+Key Concepts
+------------
+**Edge Snapping**: When a user clicks mid-way along a road, the system projects the
+click point onto the nearest edge geometry rather than snapping to the nearest junction.
+This produces more accurate routes that don't backtrack to intersections.
+
+**Segment Types**: Each route feature has a `segmentType` property indicating how the
+geometry was processed.
+
+- `"full"` - Complete edge traversed from start_node to end_node
+- `"trimmed"` - Path edge cut to start/end at a snap point
+- `"lead"` - Lead segment connecting snap point to routing node (different road)
+- `"inline"` - Portion of edge when both start and end are on same edge
+
+**Lead Segments vs Trimmed Edges**:
+- Lead segments (`lead`) are added when the snap point is on a DIFFERENT road
+  than what the path traverses. They connect the snap point to the junction.
+- Trimmed edges (`trimmed`) are used when the first/last path edge is on the SAME
+  road as the snap edge. The edge is cut to start/end at the snap point.
+
+Example: User clicks mid-segment on road AB, routes to mid-segment on road CD
+- If path is B→C→D: First edge (AB portion) is a lead-in, CD is trimmed
+- If path is A→B→C→D: AB is trimmed at start, CD is trimmed at end
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import networkx as nx
+from shapely import make_valid
+from shapely.geometry import LineString, Point
+from shapely.ops import substring, unary_union
+from shapely.prepared import prep
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from networkx import DiGraph
+    from shapely.geometry.base import BaseGeometry
+
+    from .constraint_provider import ConstraintProvider
+    from .graph_cache import RoutingCache
+
+logger = logging.getLogger(__name__)
+
+METERS_TO_MILES = 0.000621371
+METERS_TO_FEET = 3.28084
+MPS_TO_MPH = 2.23694
+
+# Geometry thresholds
+NEAR_ENDPOINT = 0.01  # Fraction: "essentially at endpoint"
+MIN_SEGMENT_COORDS = 2  # Minimum coordinates for a valid LineString
+
+DEFAULT_SPEED_MPS = 13.4  # 30 mph in m/s
+
+
+class SegmentType(StrEnum):
+    """Route segment type indicating how geometry was processed."""
+
+    FULL = "full"
+    TRIMMED = "trimmed"
+    LEAD = "lead"
+    INLINE = "inline"
+
+
+@dataclass(frozen=True)
+class RoutePoint:
+    """A geographic point for routing. Uses lon/lat order to match GeoJSON convention."""
+
+    lon: float
+    lat: float
+
+
+@dataclass(frozen=True)
+class SnapResult:
+    """Result of snapping a point to the road network.
+
+    When edge snapping is used, the point is projected onto the nearest edge geometry.
+    The node_id is the endpoint chosen for routing based on destination direction.
+    """
+
+    node_id: str
+    name: str
+    snapped_lon: float
+    snapped_lat: float
+    snap_distance_feet: float
+    edge_key: tuple[str, str] | None = None
+    fraction: float = 0.0
+
+
+@dataclass
+class RouteAccumulator:
+    """Accumulates route data during path processing."""
+
+    features: list[dict] = field(default_factory=list)
+    total_meters: float = 0.0
+    total_seconds: float = 0.0
+    start_name: str = ""
+    end_name: str = ""
+
+    def add_feature(self, feature: dict) -> None:
+        """Add feature and update totals."""
+        self.features.append(feature)
+        self.total_meters += feature["properties"]["distanceMiles"] / METERS_TO_MILES
+        self.total_seconds += feature["properties"]["durationSeconds"]
+        name = feature["properties"].get("name", "")
+        if name:
+            if not self.start_name:
+                self.start_name = name
+            self.end_name = name
+
+
+class RouteCalculator:
+    """Calculates routes between two geographic points on the road network.
+
+    Uses A* pathfinding with distance weights (shortest path by distance).
+    Supports edge snapping for accurate mid-segment routing, and integrates
+    with constraint providers for road closures, flood zones, and vehicle restrictions.
+
+    The calculator produces GeoJSON FeatureCollection responses with:
+    - Individual features for each road segment (with osid, name, distance, duration)
+    - Summary properties (total distance, duration, average speed)
+    - Start/end snap information (requested vs snapped coordinates, snap distance)
+    """
+
+    def __init__(
+        self,
+        graph_provider: RoutingCache,
+        constraint_provider: ConstraintProvider | None = None,
+    ) -> None:
+        """Initialize the route calculator with graph and constraint providers."""
+        self._graph_provider = graph_provider
+        self._constraint_provider = constraint_provider
+
+    def calculate_route(
+        self,
+        start: RoutePoint,
+        end: RoutePoint,
+        scenario_id: UUID | None = None,
+        user_id: UUID | None = None,
+        vehicle: str | None = None,
+    ) -> dict:
+        """Calculate a route between two points, applying constraints.
+
+        Args:
+            start: Starting point (lon, lat)
+            end: Ending point (lon, lat)
+            scenario_id: Optional scenario ID for constraint lookup
+            user_id: Optional user ID for constraint lookup
+            vehicle: Optional vehicle type for restriction checks (e.g., "HGV")
+
+        Returns:
+            GeoJSON FeatureCollection with route geometry and properties.
+        """
+        blocked_edges: set[tuple[str, str]] = set()
+        if self._constraint_provider:
+            blocked_geometries = self._constraint_provider.get_blocked_geometries(
+                scenario_id, user_id, vehicle
+            )
+            blocked_edges = self._compute_blocked_edges(blocked_geometries)
+
+        if blocked_edges:
+            G = self._graph_provider.get_graph().copy()
+            edges_to_remove = [(u, v) for u, v in blocked_edges if G.has_edge(u, v)]
+            G.remove_edges_from(edges_to_remove)
+        else:
+            G = self._graph_provider.get_graph()
+
+        start_snap = self._find_nearest_edge(G, start.lon, start.lat)
+        end_snap = self._find_nearest_edge(G, end.lon, end.lat)
+
+        if start_snap is None or end_snap is None:
+            logger.debug("Could not find nearest nodes for start or end")
+            return self._empty_route()
+
+        if start_snap.node_id == end_snap.node_id:
+            return self._handle_same_node_route(G, start, end, start_snap, end_snap)
+
+        try:
+            path = nx.astar_path(
+                G,
+                start_snap.node_id,
+                end_snap.node_id,
+                heuristic=lambda u, v: self._haversine_heuristic(G, u, v),
+                weight="length_m",
+            )
+        except nx.NetworkXNoPath:
+            logger.debug("No path found between %s and %s", start_snap.node_id, end_snap.node_id)
+            return self._empty_route()
+
+        return self._path_to_geojson(G, path, start, end, start_snap, end_snap)
+
+    def _compute_blocked_edges(
+        self,
+        blocked_geometries: list[BaseGeometry],
+    ) -> set[tuple[str, str]]:
+        """Determine which graph edges intersect with blocked geometries."""
+        if not blocked_geometries:
+            return set()
+
+        edge_index, edge_keys, edge_geoms = self._graph_provider.get_edge_index()
+        if edge_index is None:
+            return set()
+
+        blocked_area = make_valid(unary_union(blocked_geometries))
+        prepared_area = prep(blocked_area)
+
+        blocked: set[tuple[str, str]] = set()
+        candidate_indices = edge_index.query(blocked_area)
+        for idx in candidate_indices:
+            if prepared_area.intersects(edge_geoms[idx]):
+                u, v = edge_keys[idx]
+                blocked.add((u, v))
+                blocked.add((v, u))
+
+        logger.debug("Found %d blocked edges from constraint geometries", len(blocked) // 2)
+        return blocked
+
+    def _find_nearest_edge(
+        self,
+        G: DiGraph,
+        lon: float,
+        lat: float,
+    ) -> SnapResult | None:
+        """Find the nearest point on any edge using spatial index.
+
+        Projects the point onto the nearest edge geometry and returns a SnapResult
+        with the closer routing node.
+
+        Returns None if no nearby edge is found within the search radius.
+        Raises RuntimeError if the edge index is not available.
+        """
+        edge_index, edge_keys, edge_geoms = self._graph_provider.get_edge_index()
+
+        if edge_index is None or not edge_keys:
+            raise RuntimeError("Edge spatial index not available - graph not properly loaded")
+
+        point = Point(lon, lat)
+
+        # Query spatial index for nearby edges (buffer in degrees, ~1km at UK latitudes)
+        candidate_indices = list(edge_index.query(point.buffer(0.01)))
+
+        if not candidate_indices:
+            # Expand search if nothing found
+            candidate_indices = list(edge_index.query(point.buffer(0.1)))
+
+        if not candidate_indices:
+            return None
+
+        best_dist = float("inf")
+        best_result: SnapResult | None = None
+
+        for idx in candidate_indices:
+            if idx >= len(edge_keys):
+                continue
+
+            edge_geom = edge_geoms[idx]
+            u, v = edge_keys[idx]
+
+            # Skip edges not in current graph (may have been blocked)
+            if not G.has_edge(u, v):
+                continue
+
+            # Project point onto edge geometry
+            projected = edge_geom.interpolate(edge_geom.project(point))
+            dist_degrees = point.distance(projected)
+
+            if dist_degrees < best_dist:
+                best_dist = dist_degrees
+                fraction = edge_geom.project(point, normalized=True)
+
+                # Invert fraction if geometry direction differs from edge direction
+                if self._is_geometry_inverted(G, edge_geom, u):
+                    fraction = 1 - fraction
+
+                route_node = self._choose_routing_node(u, v, fraction)
+
+                name = G.get_edge_data(u, v, {}).get("name", "")
+                dist_meters = self._haversine_distance(lon, lat, projected.x, projected.y)
+                best_result = SnapResult(
+                    node_id=route_node,
+                    name=name,
+                    snapped_lon=projected.x,
+                    snapped_lat=projected.y,
+                    snap_distance_feet=dist_meters * METERS_TO_FEET,
+                    edge_key=(u, v),
+                    fraction=fraction,
+                )
+
+        return best_result
+
+    @staticmethod
+    def _choose_routing_node(u: str, v: str, fraction: float) -> str:
+        """Choose the closer endpoint of an edge to route from."""
+        return u if fraction < 0.5 else v  # noqa: PLR2004
+
+    @staticmethod
+    def _linestring_length_meters(geom: LineString) -> float:
+        """Calculate geodesic length of a LineString by summing haversine between vertices."""
+        coords = list(geom.coords)
+        total = 0.0
+        for i in range(len(coords) - 1):
+            total += RouteCalculator._haversine_distance(
+                coords[i][0], coords[i][1], coords[i + 1][0], coords[i + 1][1]
+            )
+        return total
+
+    @staticmethod
+    def _haversine_distance(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+        """Calculate Haversine distance between two points in meters."""
+        R = 6371000
+        phi1 = math.radians(lat1)
+        phi2 = math.radians(lat2)
+        dphi = math.radians(lat2 - lat1)
+        dlambda = math.radians(lon2 - lon1)
+
+        a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+        return R * c
+
+    def _haversine_heuristic(self, G: DiGraph, u: str, v: str) -> float:
+        """Calculate Haversine distance heuristic for A* pathfinding."""
+        u_data = G.nodes.get(u, {})
+        v_data = G.nodes.get(v, {})
+
+        u_lon = u_data.get("x")
+        u_lat = u_data.get("y")
+        v_lon = v_data.get("x")
+        v_lat = v_data.get("y")
+
+        if None in (u_lon, u_lat, v_lon, v_lat):
+            return 0
+
+        return self._haversine_distance(u_lon, u_lat, v_lon, v_lat)
+
+    @staticmethod
+    def _empty_route() -> dict:
+        """Return an empty GeoJSON FeatureCollection for when no route exists."""
+        return {
+            "type": "FeatureCollection",
+            "features": [],
+            "properties": {
+                "hasRoute": False,
+            },
+        }
+
+    def _is_geometry_inverted(self, G: DiGraph, edge_geom: LineString, u: str) -> bool:
+        """Check if edge geometry direction is inverted relative to edge (u, v).
+
+        For bidirectional roads, both directions (u->v and v->u) share the same
+        stored geometry. This checks if the geometry's first coordinate matches
+        node u. If not, the geometry is "inverted" (starts at v instead of u).
+        """
+        u_data = G.nodes.get(u, {})
+        u_lon, u_lat = u_data.get("x"), u_data.get("y")
+        if u_lon is None or u_lat is None:
+            return False
+
+        geom_start = edge_geom.coords[0]
+        return geom_start[0] != u_lon or geom_start[1] != u_lat
+
+    def _get_edge_segment(
+        self,
+        G: DiGraph,
+        u: str,
+        v: str,
+        start_frac: float = 0.0,
+        end_frac: float = 1.0,
+    ) -> LineString | None:
+        """Extract a segment of edge geometry between two fractions.
+
+        Fractions are in edge direction: 0.0 = at node u, 1.0 = at node v.
+        Returns geometry oriented from start_frac toward end_frac.
+        Handles geometry inversion internally - callers don't need to know about it.
+
+        Args:
+            G: The road network graph
+            u, v: Edge endpoints (edge direction, not geometry direction)
+            start_frac: Starting point as fraction along edge (0-1)
+            end_frac: Ending point as fraction along edge (0-1)
+
+        Returns:
+            LineString from start_frac to end_frac, or None if geometry unavailable.
+        """
+        edge_data = G.get_edge_data(u, v, {})
+        geom = edge_data.get("geometry")
+        if not geom:
+            return None
+
+        geom_inverted = self._is_geometry_inverted(G, geom, u)
+
+        # Convert edge fractions to geometry fractions
+        if geom_inverted:
+            gf_start = 1 - start_frac
+            gf_end = 1 - end_frac
+        else:
+            gf_start = start_frac
+            gf_end = end_frac
+
+        # Ensure gf_start < gf_end for substring (it requires ordered fractions)
+        needs_reverse = gf_start > gf_end
+        if needs_reverse:
+            gf_start, gf_end = gf_end, gf_start
+
+        segment = substring(geom, gf_start, gf_end, normalized=True)
+
+        if segment.is_empty or len(segment.coords) < MIN_SEGMENT_COORDS:
+            return None
+
+        # Reverse if needed to match requested direction (start_frac → end_frac)
+        if needs_reverse:
+            segment = LineString(segment.coords[::-1])
+
+        return segment
+
+    @staticmethod
+    def _snap_fraction_on_edge(snap: SnapResult, edge: tuple[str, str]) -> float:
+        """Get snap fraction relative to the given edge direction.
+
+        If snap was on edge (u,v) and we want fraction on (u,v): return as-is
+        If snap was on edge (v,u) and we want fraction on (u,v): return 1 - fraction
+        """
+        if snap.edge_key == edge:
+            return snap.fraction
+        if snap.edge_key == (edge[1], edge[0]):
+            return 1 - snap.fraction
+        raise ValueError(f"Snap edge {snap.edge_key} doesn't match {edge}")
+
+    @staticmethod
+    def _make_segment_feature(  # noqa: PLR0913
+        coords: list,
+        osid: str,
+        name: str,
+        segment_type: SegmentType,
+        distance_miles: float,
+        duration_seconds: float,
+        speed_mph: float,
+    ) -> dict:
+        """Create a GeoJSON Feature dict for a route segment."""
+        return {
+            "type": "Feature",
+            "properties": {
+                "osid": osid,
+                "name": name,
+                "segmentType": segment_type,
+                "distanceMiles": round(distance_miles, 4),
+                "durationSeconds": duration_seconds,
+                "speedMph": round(speed_mph, 1) if speed_mph else 0,
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": coords,
+            },
+        }
+
+    def _junction_route(
+        self,
+        G: DiGraph,
+        start: RoutePoint,
+        end: RoutePoint,
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict:
+        """Create a route when start and end snap to different edges at the same junction.
+
+        Both points meet at the same routing node but are on different roads.
+        The route consists of lead-in (snap→node) and lead-out (node→snap) segments.
+        """
+        acc = RouteAccumulator()
+
+        # Create lead-in segment from start snap to junction
+        lead_in = self._create_lead_segment(G, start_snap, is_start=True)
+        if lead_in:
+            acc.add_feature(lead_in)
+
+        # Create lead-out segment from junction to end snap
+        lead_out = self._create_lead_segment(G, end_snap, is_start=False)
+        if lead_out:
+            # Connect lead-out to lead-in if both exist
+            if lead_in:
+                lead_in_end = lead_in["geometry"]["coordinates"][-1]
+                lead_out["geometry"]["coordinates"][0] = lead_in_end
+            acc.add_feature(lead_out)
+
+        if not acc.features:
+            return self._empty_route()
+
+        return self._build_route_response(acc, start, end, start_snap, end_snap)
+
+    def _same_edge_route(
+        self,
+        G: DiGraph,
+        start: RoutePoint,
+        end: RoutePoint,
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict:
+        """Create a route when start and end are on the same edge.
+
+        Extracts the portion of the edge geometry between the two snap points.
+        """
+        if start_snap.edge_key is None:
+            return self._empty_route()
+
+        u, v = start_snap.edge_key
+        edge_data = G.get_edge_data(u, v, {})
+
+        # Get fractions in order (start to end along edge)
+        f1, f2 = start_snap.fraction, end_snap.fraction
+        if f1 > f2:
+            f1, f2 = f2, f1
+            start_snap, end_snap = end_snap, start_snap
+
+        # Extract segment between the two snap points
+        segment = self._get_edge_segment(G, u, v, f1, f2)
+        if segment is None:
+            return self._empty_route()
+
+        segment_length_m = self._linestring_length_meters(segment)
+        speed_mps = edge_data.get("speed_mps", DEFAULT_SPEED_MPS)
+        travel_time_s = segment_length_m / speed_mps if speed_mps > 0 else 0
+
+        feature = self._make_segment_feature(
+            coords=list(segment.coords),
+            osid=edge_data.get("osid", ""),
+            name=edge_data.get("name", start_snap.name),
+            segment_type=SegmentType.INLINE,
+            distance_miles=segment_length_m * METERS_TO_MILES,
+            duration_seconds=travel_time_s,
+            speed_mph=speed_mps * MPS_TO_MPH,
+        )
+
+        acc = RouteAccumulator()
+        acc.add_feature(feature)
+        return self._build_route_response(acc, start, end, start_snap, end_snap)
+
+    def _handle_same_node_route(
+        self,
+        G: DiGraph,
+        start: RoutePoint,
+        end: RoutePoint,
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict:
+        """Handle routing when start and end snap to the same node.
+
+        Three cases:
+        - Same edge, different fractions: extract inline segment
+        - Different edges at same junction: connect via lead segments
+        - Otherwise: no valid route
+        """
+        # Same edge - create direct segment between snap points
+        if (
+            start_snap.edge_key is not None
+            and start_snap.edge_key == end_snap.edge_key
+            and start_snap.fraction != end_snap.fraction
+        ):
+            return self._same_edge_route(G, start, end, start_snap, end_snap)
+
+        # Different edges meeting at same junction - connect via leads
+        if start_snap.edge_key is not None and end_snap.edge_key is not None:
+            return self._junction_route(G, start, end, start_snap, end_snap)
+
+        logger.debug("Start and end are the same node with no valid route")
+        return self._empty_route()
+
+    def _create_lead_segment(
+        self,
+        G: DiGraph,
+        snap: SnapResult,
+        is_start: bool,
+    ) -> dict | None:
+        """Create a lead-in or lead-out segment connecting snap point to routing node.
+
+        For start: creates segment from snap point TO the first path node.
+        For end: creates segment from last path node TO the snap point.
+        """
+        if snap.edge_key is None:
+            return None
+
+        u, v = snap.edge_key
+        edge_data = G.get_edge_data(u, v, {})
+        fraction = snap.fraction
+
+        # Skip if snap point is essentially at the routing node
+        at_u = fraction <= NEAR_ENDPOINT
+        at_v = fraction >= 1 - NEAR_ENDPOINT
+        if (snap.node_id == u and at_u) or (snap.node_id == v and at_v):
+            return None
+
+        # Lead segment connects snap point to routing node:
+        # - Lead-in (is_start=True): snap point → routing node (start of route)
+        # - Lead-out (is_start=False): routing node → snap point (end of route)
+        # Node u is at fraction 0, node v at fraction 1
+        if snap.node_id == u and is_start:
+            segment = self._get_edge_segment(G, u, v, fraction, 0)
+        elif snap.node_id == u:
+            segment = self._get_edge_segment(G, u, v, 0, fraction)
+        elif is_start:
+            segment = self._get_edge_segment(G, u, v, fraction, 1)
+        else:
+            segment = self._get_edge_segment(G, u, v, 1, fraction)
+
+        if segment is None:
+            return None
+
+        segment_length_m = self._linestring_length_meters(segment)
+        speed_mps = edge_data.get("speed_mps", DEFAULT_SPEED_MPS)
+        travel_time_s = segment_length_m / speed_mps if speed_mps > 0 else 0
+
+        return self._make_segment_feature(
+            coords=list(segment.coords),
+            osid=edge_data.get("osid", ""),
+            name=edge_data.get("name", snap.name),
+            segment_type=SegmentType.LEAD,
+            distance_miles=segment_length_m * METERS_TO_MILES,
+            duration_seconds=travel_time_s,
+            speed_mph=speed_mps * MPS_TO_MPH,
+        )
+
+    @staticmethod
+    def _is_same_road(edge1: tuple[str, str], edge2: tuple[str, str] | None) -> bool:
+        """Check if two edges are on the same road (same or reverse direction)."""
+        if edge2 is None:
+            return False
+        return edge1 == edge2 or edge1 == (edge2[1], edge2[0])
+
+    def _trim_edge_to_snap(
+        self,
+        G: DiGraph,
+        path_edge: tuple[str, str],
+        snap: SnapResult,
+        from_start: bool,
+    ) -> dict | None:
+        """Trim a path edge to start or end at the snap point.
+
+        Args:
+            from_start: If True, trim from path edge start to snap point.
+                       If False, trim from snap point to path edge end.
+        """
+        if snap.edge_key is None:
+            return None
+
+        u, v = path_edge
+        edge_data = G.get_edge_data(u, v, {})
+
+        # Convert snap fraction to path_edge direction
+        path_fraction = self._snap_fraction_on_edge(snap, path_edge)
+
+        # Extract the appropriate portion
+        if from_start:
+            # From edge start (0) to snap point
+            segment = self._get_edge_segment(G, u, v, 0, path_fraction)
+            proportion = path_fraction
+        else:
+            # From snap point to edge end (1)
+            segment = self._get_edge_segment(G, u, v, path_fraction, 1)
+            proportion = 1 - path_fraction
+
+        if segment is None:
+            return None
+
+        full_length = edge_data.get("length_m", 0)
+        full_time = edge_data.get("travel_time_s", 0)
+        speed_mps = edge_data.get("speed_mps", 0)
+
+        return self._make_segment_feature(
+            coords=list(segment.coords),
+            osid=edge_data.get("osid", ""),
+            name=edge_data.get("name", ""),
+            segment_type=SegmentType.TRIMMED,
+            distance_miles=full_length * proportion * METERS_TO_MILES,
+            duration_seconds=full_time * proportion,
+            speed_mph=speed_mps * MPS_TO_MPH,
+        )
+
+    def _path_to_geojson(  # noqa: PLR0913
+        self,
+        G: DiGraph,
+        path: list[str],
+        start: RoutePoint,
+        end: RoutePoint,
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict:
+        """Convert a path of node IDs to GeoJSON FeatureCollection."""
+        acc = RouteAccumulator()
+
+        first_edge = (path[0], path[1]) if len(path) >= MIN_SEGMENT_COORDS else None
+        last_edge = (path[-2], path[-1]) if len(path) >= MIN_SEGMENT_COORDS else None
+        trim_first = first_edge and self._is_same_road(first_edge, start_snap.edge_key)
+        trim_last = last_edge and self._is_same_road(last_edge, end_snap.edge_key)
+
+        path_features: list[dict] = []
+        for i in range(len(path) - 1):
+            edge = (path[i], path[i + 1])
+            is_first, is_last = i == 0, i == len(path) - 2
+
+            s_snap = start_snap if is_first and trim_first else None
+            e_snap = end_snap if is_last and trim_last else None
+
+            feature = self._process_path_edge(G, edge, s_snap, e_snap)
+            if feature:
+                path_features.append(feature)
+
+        path_start_coord = None
+        path_end_coord = None
+        if path_features:
+            path_start_coord = tuple(path_features[0]["geometry"]["coordinates"][0])
+            path_end_coord = tuple(path_features[-1]["geometry"]["coordinates"][-1])
+
+        # Add lead-in if first edge wasn't trimmed
+        if not trim_first:
+            lead_in = self._add_lead_segment(
+                G, start_snap, is_start=True, connect_coord=path_start_coord
+            )
+            if lead_in:
+                acc.add_feature(lead_in)
+
+        for feature in path_features:
+            acc.add_feature(feature)
+
+        # Add lead-out if last edge wasn't trimmed
+        if not trim_last:
+            lead_out = self._add_lead_segment(
+                G, end_snap, is_start=False, connect_coord=path_end_coord
+            )
+            if lead_out:
+                acc.add_feature(lead_out)
+
+        return self._build_route_response(acc, start, end, start_snap, end_snap)
+
+    def _trim_both_ends(
+        self,
+        G: DiGraph,
+        path_edge: tuple[str, str],
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict | None:
+        """Trim an edge at both ends for start and end snap points."""
+        if start_snap.edge_key is None or end_snap.edge_key is None:
+            return None
+
+        u, v = path_edge
+        edge_data = G.get_edge_data(u, v, {})
+
+        start_frac = self._snap_fraction_on_edge(start_snap, path_edge)
+        end_frac = self._snap_fraction_on_edge(end_snap, path_edge)
+
+        if start_frac > end_frac:
+            start_frac, end_frac = end_frac, start_frac
+
+        segment = self._get_edge_segment(G, u, v, start_frac, end_frac)
+        if segment is None:
+            return None
+
+        full_length = edge_data.get("length_m", 0)
+        full_time = edge_data.get("travel_time_s", 0)
+        speed_mps = edge_data.get("speed_mps", 0)
+        proportion = end_frac - start_frac
+
+        return self._make_segment_feature(
+            coords=list(segment.coords),
+            osid=edge_data.get("osid", ""),
+            name=edge_data.get("name", ""),
+            segment_type=SegmentType.TRIMMED,
+            distance_miles=full_length * proportion * METERS_TO_MILES,
+            duration_seconds=full_time * proportion,
+            speed_mph=speed_mps * MPS_TO_MPH,
+        )
+
+    def _process_path_edge(
+        self,
+        G: DiGraph,
+        edge: tuple[str, str],
+        start_snap: SnapResult | None,
+        end_snap: SnapResult | None,
+    ) -> dict | None:
+        """Process a single path edge, applying trimming if needed.
+
+        Args:
+            edge: The (u, v) edge to process
+            start_snap: If provided, trim from this snap point (edge start)
+            end_snap: If provided, trim to this snap point (edge end)
+
+        Returns:
+            GeoJSON Feature dict, or None if no geometry
+        """
+        u, v = edge
+        edge_data = G.get_edge_data(u, v, {})
+
+        if start_snap and end_snap:
+            return self._trim_both_ends(G, edge, start_snap, end_snap)
+
+        if start_snap:
+            return self._trim_edge_to_snap(G, edge, start_snap, from_start=False)
+
+        if end_snap:
+            return self._trim_edge_to_snap(G, edge, end_snap, from_start=True)
+
+        # Full edge - no trimming needed
+        geom = edge_data.get("geometry")
+        if not geom:
+            return None
+
+        return self._make_segment_feature(
+            coords=list(geom.coords),
+            osid=edge_data.get("osid", ""),
+            name=edge_data.get("name", ""),
+            segment_type=SegmentType.FULL,
+            distance_miles=edge_data.get("length_m", 0) * METERS_TO_MILES,
+            duration_seconds=edge_data.get("travel_time_s", 0),
+            speed_mph=edge_data.get("speed_mps", 0) * MPS_TO_MPH,
+        )
+
+    def _add_lead_segment(
+        self,
+        G: DiGraph,
+        snap: SnapResult,
+        is_start: bool,
+        connect_coord: tuple[float, float] | None,
+    ) -> dict | None:
+        """Create lead segment and stitch coordinates if needed.
+
+        Args:
+            snap: The snap result for this endpoint
+            is_start: True for lead-in, False for lead-out
+            connect_coord: Coordinate to connect to (path start/end)
+
+        Returns:
+            GeoJSON Feature with coordinates stitched, or None
+        """
+        lead = self._create_lead_segment(G, snap, is_start=is_start)
+        if not lead:
+            return None
+
+        if connect_coord:
+            coords = lead["geometry"]["coordinates"]
+            if is_start and coords[-1] != list(connect_coord):
+                # Lead-in: stitch end of segment to path start
+                coords[-1] = list(connect_coord)
+            elif not is_start and coords[0] != list(connect_coord):
+                # Lead-out: stitch start of segment to path end
+                coords[0] = list(connect_coord)
+
+        return lead
+
+    def _build_route_response(
+        self,
+        acc: RouteAccumulator,
+        start: RoutePoint,
+        end: RoutePoint,
+        start_snap: SnapResult,
+        end_snap: SnapResult,
+    ) -> dict:
+        """Build the final GeoJSON FeatureCollection response."""
+        distance_miles = acc.total_meters * METERS_TO_MILES
+        duration_minutes = acc.total_seconds / 60
+        avg_speed_mph = (
+            (distance_miles / (acc.total_seconds / 3600)) if acc.total_seconds > 0 else 0
+        )
+
+        return {
+            "type": "FeatureCollection",
+            "features": acc.features,
+            "properties": {
+                "hasRoute": True,
+                "distanceMiles": round(distance_miles, 2),
+                "durationMinutes": round(duration_minutes, 1),
+                "averageSpeedMph": round(avg_speed_mph, 1),
+                "start": {
+                    "name": acc.start_name or start_snap.name or "Unknown",
+                    "requested": {"lat": start.lat, "lon": start.lon},
+                    "snapped": {"lat": start_snap.snapped_lat, "lon": start_snap.snapped_lon},
+                    "snapDistanceFeet": round(start_snap.snap_distance_feet, 1),
+                },
+                "end": {
+                    "name": acc.end_name or end_snap.name or "Unknown",
+                    "requested": {"lat": end.lat, "lon": end.lon},
+                    "snapped": {"lat": end_snap.snapped_lat, "lon": end_snap.snapped_lon},
+                    "snapDistanceFeet": round(end_snap.snap_distance_feet, 1),
+                },
+            },
+        }

--- a/backend/vista-python-api/src/api/serializers/__init__.py
+++ b/backend/vista-python-api/src/api/serializers/__init__.py
@@ -28,6 +28,7 @@ from .focus_area import (
     FocusAreaUpdateSerializer,
 )
 from .group import GroupMembershipSerializer, GroupSerializer
+from .route import RouteCalculateSerializer
 from .scenario import ScenarioSerializer
 from .user import IdpUserSerializer
 from .visible_asset_type import (
@@ -66,6 +67,7 @@ __all__ = [
     "GroupMembershipSerializer",
     "GroupSerializer",
     "IdpUserSerializer",
+    "RouteCalculateSerializer",
     "ScenarioAssetSerializer",
     "ScenarioSerializer",
     "VisibleAssetTypeResponseSerializer",

--- a/backend/vista-python-api/src/api/serializers/route.py
+++ b/backend/vista-python-api/src/api/serializers/route.py
@@ -1,0 +1,17 @@
+"""Serializers for route calculation."""
+
+from rest_framework import serializers
+
+
+class RouteCalculateSerializer(serializers.Serializer):
+    """Serializer for route calculation input."""
+
+    start_lat = serializers.FloatField(min_value=-90, max_value=90)
+    start_lon = serializers.FloatField(min_value=-180, max_value=180)
+    end_lat = serializers.FloatField(min_value=-90, max_value=90)
+    end_lon = serializers.FloatField(min_value=-180, max_value=180)
+    vehicle = serializers.ChoiceField(
+        choices=["Car", "EmergencyVehicle", "HGV"],
+        required=False,
+        allow_null=True,
+    )

--- a/backend/vista-python-api/src/api/tests/management/commands/test_refresh_road_network.py
+++ b/backend/vista-python-api/src/api/tests/management/commands/test_refresh_road_network.py
@@ -1,0 +1,113 @@
+"""Test cases for the refresh road network management command."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from api.management.commands.refresh_road_network import Command, RoadNetworkHandler
+from api.models.road_link import RoadLink
+from django.contrib.gis.geos import LineString
+
+ROAD_LINK_FEATURE = {
+    "id": "road-link-1",
+    "type": "Feature",
+    "properties": {
+        "geometry_length_m": 100.0,
+        "directionality": "Both Directions",
+        "roadclassification": "A Road",
+        "routehierarchy": "A Road",
+        "roadclassificationnumber": "A3055",
+        "description": "Single Carriageway",
+        "operationalstate": "Open",
+        "trunkroad": False,
+        "primaryroute": False,
+        "startnode": "node-a",
+        "endnode": "node-b",
+        "name1_text": "Test Road",
+        "versiondate": "2025-06-15T00:00:00Z",
+    },
+    "geometry": {
+        "type": "LineString",
+        "coordinates": [[-1.17, 50.63], [-1.18, 50.64]],
+    },
+}
+
+SPEED_FEATURE = {
+    "id": "speed-1",
+    "type": "Feature",
+    "properties": {
+        "osid": "road-link-1",
+        "indicativespeedlimit_mph": 40.0,
+    },
+    "geometry": {
+        "type": "LineString",
+        "coordinates": [[-1.17, 50.63], [-1.18, 50.64]],
+    },
+}
+
+
+def _create_road_link(**overrides):
+    """Create a RoadLink in the DB with sensible defaults."""
+    defaults = {
+        "osid": "existing-link-1",
+        "geometry": LineString((-1.17, 50.63), (-1.18, 50.64), srid=4326),
+        "length_m": 100.0,
+        "start_node": "node-a",
+        "end_node": "node-b",
+    }
+    defaults.update(overrides)
+    return RoadLink.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestRefreshRoadNetwork:
+    """Tests for the refresh road network command."""
+
+    @patch.object(RoadNetworkHandler, "fetch_all_from_collection", new_callable=AsyncMock)
+    def test_creates_road_links(self, mock_fetch):
+        """Road links are created from fetched data."""
+        mock_fetch.side_effect = [[ROAD_LINK_FEATURE], [SPEED_FEATURE]]
+
+        Command().handle()
+
+        assert RoadLink.objects.count() == 1
+        assert RoadLink.objects.first().osid == "road-link-1"
+
+    @patch.object(RoadNetworkHandler, "fetch_all_from_collection", new_callable=AsyncMock)
+    def test_deletes_existing_before_insert(self, mock_fetch):
+        """Existing road links are deleted before inserting new ones."""
+        _create_road_link()
+        mock_fetch.side_effect = [[ROAD_LINK_FEATURE], [SPEED_FEATURE]]
+
+        Command().handle()
+
+        assert RoadLink.objects.count() == 1
+        assert RoadLink.objects.first().osid == "road-link-1"
+
+    @patch.object(RoadNetworkHandler, "fetch_all_from_collection", new_callable=AsyncMock)
+    def test_stores_versiondate(self, mock_fetch):
+        """Versiondate from OS NGD is stored on the road link."""
+        mock_fetch.side_effect = [[ROAD_LINK_FEATURE], []]
+
+        Command().handle()
+
+        link = RoadLink.objects.first()
+        assert link.versiondate == datetime(2025, 6, 15, tzinfo=UTC)
+
+    @patch.object(RoadNetworkHandler, "fetch_all_from_collection", new_callable=AsyncMock)
+    def test_applies_speed_lookup(self, mock_fetch):
+        """Speed data from RAMI collection is joined to road links."""
+        mock_fetch.side_effect = [[ROAD_LINK_FEATURE], [SPEED_FEATURE]]
+
+        Command().handle()
+
+        assert RoadLink.objects.first().speed_limit_mph == 40
+
+    @patch.object(RoadNetworkHandler, "fetch_all_from_collection", new_callable=AsyncMock)
+    def test_no_speed_data_leaves_null(self, mock_fetch):
+        """Road links without matching speed data have null speed_limit_mph."""
+        mock_fetch.side_effect = [[ROAD_LINK_FEATURE], []]
+
+        Command().handle()
+
+        assert RoadLink.objects.first().speed_limit_mph is None

--- a/backend/vista-python-api/src/api/tests/repository/external/test_road_link_mapper.py
+++ b/backend/vista-python-api/src/api/tests/repository/external/test_road_link_mapper.py
@@ -1,0 +1,191 @@
+"""Tests for mapping OS NGD Road Link data to RoadLink model."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from api.models.road_link import (
+    Directionality,
+    FormOfWay,
+    OperationalState,
+    RoadClassification,
+    RouteHierarchy,
+)
+from api.repository.external.road_link_mapper import RoadLinkMapper
+
+
+@pytest.fixture
+def road_link_feature():
+    """Stub OS NGD Road Link feature matching real API response format."""
+    return {
+        "id": "92433396-4649-477a-af60-6c002d18b036",
+        "type": "Feature",
+        "properties": {
+            "osid": "92433396-4649-477a-af60-6c002d18b036",
+            "geometry_length_m": 155.495,
+            "directionality": "In Direction",
+            "roadclassification": "A Road",
+            "routehierarchy": "A Road",
+            "roadclassificationnumber": "A3055",
+            "description": "Single Carriageway",
+            "operationalstate": "Open",
+            "trunkroad": True,
+            "primaryroute": False,
+            "startnode": "6e60d6a9-c94f-48e9-a14e-7c33c5bc0b41",
+            "endnode": "10029f36-8a02-4d1a-9fef-6904cfa0c2f3",
+            "name1_text": "Sandown Road",
+        },
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[-1.17102, 50.6397725], [-1.1720083, 50.6385359]],
+        },
+    }
+
+
+@pytest.fixture
+def minimal_road_link_feature():
+    """Stub OS NGD Road Link feature with minimal fields."""
+    return {
+        "id": "923ea1b8-26b6-4608-a287-254b527baab5",
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[-1.2031812, 50.6524468], [-1.2031555, 50.6524348]],
+        },
+    }
+
+
+@pytest.fixture
+def speed_lookup():
+    """Stub speed lookup dictionary."""
+    return {
+        "92433396-4649-477a-af60-6c002d18b036": 40.0,
+        "other-uuid-not-used": 60.0,
+    }
+
+
+class TestRoadLinkMapper:
+    """Tests for the RoadLinkMapper."""
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_with_all_fields(self, road_link_feature, speed_lookup):
+        """Test mapping with all fields present."""
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature, speed_lookup)
+
+        assert road_link.osid == "92433396-4649-477a-af60-6c002d18b036"
+        assert road_link.length_m == 155.495
+        assert road_link.directionality == Directionality.IN_DIRECTION
+        assert road_link.road_classification == RoadClassification.A_ROAD
+        assert road_link.route_hierarchy == RouteHierarchy.A_ROAD
+        assert road_link.road_number == "A3055"
+        assert road_link.form_of_way == FormOfWay.SINGLE_CARRIAGEWAY
+        assert road_link.operational_state == OperationalState.OPEN
+        assert road_link.trunk_road is True
+        assert road_link.primary_route is False
+        assert road_link.start_node == "6e60d6a9-c94f-48e9-a14e-7c33c5bc0b41"
+        assert road_link.end_node == "10029f36-8a02-4d1a-9fef-6904cfa0c2f3"
+        assert road_link.name == "Sandown Road"
+        assert road_link.speed_limit_mph == 40
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_with_minimal_fields(self, minimal_road_link_feature):
+        """Test mapping with only required fields."""
+        road_link = RoadLinkMapper.map_from_os_ngd(minimal_road_link_feature)
+
+        assert road_link.osid == "923ea1b8-26b6-4608-a287-254b527baab5"
+        assert road_link.length_m == 0
+        assert road_link.directionality == Directionality.BOTH
+        assert road_link.road_classification == ""
+        assert road_link.route_hierarchy == ""
+        assert road_link.road_number is None
+        assert road_link.form_of_way == ""
+        assert road_link.operational_state == ""
+        assert road_link.trunk_road is False
+        assert road_link.primary_route is False
+        assert road_link.start_node == ""
+        assert road_link.end_node == ""
+        assert road_link.name == "923ea1b8-26b6-4608-a287-254b527baab5"  # Fallback to osid
+        assert road_link.speed_limit_mph is None
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_without_speed_lookup(self, road_link_feature):
+        """Test mapping without speed lookup."""
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature, speed_lookup=None)
+
+        assert road_link.speed_limit_mph is None
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_speed_not_in_lookup(self, road_link_feature, speed_lookup):
+        """Test mapping when osid not found in speed lookup."""
+        road_link_feature["id"] = "not-in-lookup"
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature, speed_lookup)
+
+        assert road_link.speed_limit_mph is None
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_geometry_converted(self, road_link_feature):
+        """Test that geometry is correctly converted to GEOSGeometry."""
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+
+        assert road_link.geometry is not None
+        assert road_link.geometry.geom_type == "LineString"
+        coords = list(road_link.geometry.coords)
+        assert len(coords) == 2
+        assert coords[0] == (-1.17102, 50.6397725)
+        assert coords[1] == (-1.1720083, 50.6385359)
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_directionality_values(self, road_link_feature):
+        """Test different directionality values."""
+        for direction in Directionality:
+            road_link_feature["properties"]["directionality"] = direction.value
+            road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+            assert road_link.directionality == direction
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_null_fields_from_api(self, road_link_feature):
+        """Test mapping when API returns explicit null values."""
+        road_link_feature["properties"]["roadclassificationnumber"] = None
+        road_link_feature["properties"]["name1_text"] = None
+
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+
+        assert road_link.road_number is None
+        assert road_link.name == road_link_feature["id"]  # Fallback to osid
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_name_fallback_to_road_number(self, road_link_feature):
+        """Test name falls back to road_number when name1_text is null."""
+        road_link_feature["properties"]["name1_text"] = None
+        road_link_feature["properties"]["roadclassificationnumber"] = "A3055"
+
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+
+        assert road_link.name == "A3055"
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_name_fallback_to_osid(self, road_link_feature):
+        """Test name falls back to osid when both name1_text and road_number are null."""
+        road_link_feature["properties"]["name1_text"] = None
+        road_link_feature["properties"]["roadclassificationnumber"] = None
+
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+
+        assert road_link.name == road_link_feature["id"]
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_captures_versiondate(self, road_link_feature):
+        """Test versiondate is parsed from OS NGD properties."""
+        road_link_feature["properties"]["versiondate"] = "2024-11-15T00:00:00Z"
+
+        road_link = RoadLinkMapper.map_from_os_ngd(road_link_feature)
+
+        assert road_link.versiondate == datetime(2024, 11, 15, tzinfo=UTC)
+
+    @pytest.mark.django_db
+    def test_map_from_os_ngd_versiondate_none_when_missing(self, minimal_road_link_feature):
+        """Test versiondate is None when not present in properties."""
+        road_link = RoadLinkMapper.map_from_os_ngd(minimal_road_link_feature)
+
+        assert road_link.versiondate is None

--- a/backend/vista-python-api/src/api/tests/routing/__init__.py
+++ b/backend/vista-python-api/src/api/tests/routing/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the routing module."""

--- a/backend/vista-python-api/src/api/tests/routing/test_constraint_provider.py
+++ b/backend/vista-python-api/src/api/tests/routing/test_constraint_provider.py
@@ -1,0 +1,170 @@
+"""Tests for the constraint provider."""
+
+import uuid
+
+import pytest
+from django.contrib.gis.geos import LineString, Point, Polygon
+
+from api.models import Asset, ExposureLayer, FocusArea, Scenario, VisibleExposureLayer
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.constraint_intervention import ConstraintIntervention, ConstraintInterventionType
+from api.models.exposure_layer import ExposureLayerType
+from api.routing import ConstraintProvider
+
+
+@pytest.fixture
+def road_blocks_type():
+    """Create road blocks intervention type."""
+    return ConstraintInterventionType.objects.create(
+        id=uuid.uuid4(),
+        name="Road blocks",
+        impacts_routing=True,
+    )
+
+
+@pytest.fixture
+def flood_layer_type():
+    """Create flood exposure layer type."""
+    return ExposureLayerType.objects.create(
+        id=uuid.uuid4(),
+        name="Floods",
+        impacts_exposure_score=True,
+    )
+
+
+@pytest.fixture
+def low_bridge_asset_type():
+    """Create low bridge asset type."""
+    category = AssetCategory.objects.create(id=uuid.uuid4(), name="Transport")
+    sub_category = AssetSubCategory.objects.create(
+        id=uuid.uuid4(), name="Road infrastructure", category=category
+    )
+    data_source = DataSource.objects.create(
+        id=uuid.uuid4(), name="Test Source", owner="Test", description_md="Test"
+    )
+    return AssetType.objects.create(
+        id=uuid.uuid4(),
+        name="Low bridge",
+        sub_category=sub_category,
+        data_source=data_source,
+    )
+
+
+@pytest.mark.django_db
+class TestConstraintProviderUnit:
+    """Direct unit tests for ConstraintProvider."""
+
+    def test_returns_empty_without_scenario_or_user(self):
+        """Should return empty list when scenario_id and user_id are None."""
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(None, None, None)
+        assert geometries == []
+
+    def test_returns_bridge_geometries_with_only_vehicle(self, low_bridge_asset_type):
+        """Should return bridge geometries when only vehicle is provided."""
+        Asset.objects.create(
+            id=uuid.uuid4(),
+            external_id="low-bridge-test",
+            name="Test Low Bridge",
+            type=low_bridge_asset_type,
+            geom=Point(-1.15, 50.0),
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(None, None, "HGV")
+
+        assert len(geometries) == 1
+
+    def test_line_string_constraint_is_buffered(self, road_blocks_type, mock_user_id):
+        """LineString constraints should be buffered into polygons."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+        ConstraintIntervention.objects.create(
+            name="Road closure",
+            geometry=LineString([(-1.1, 50.0), (-1.2, 50.0)]),
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=True,
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(scenario.id, mock_user_id, None)
+
+        assert len(geometries) == 1
+        geom = geometries[0]
+        assert geom.geom_type == "Polygon", (
+            f"LineString should be buffered to Polygon, got {geom.geom_type}"
+        )
+
+    def test_polygon_constraint_not_buffered(self, road_blocks_type, mock_user_id):
+        """Polygon constraints should be returned without additional buffering."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+        original_polygon = Polygon(
+            [
+                (-1.15, 49.95),
+                (-1.15, 50.05),
+                (-1.25, 50.05),
+                (-1.25, 49.95),
+                (-1.15, 49.95),
+            ]
+        )
+
+        ConstraintIntervention.objects.create(
+            name="Blocked area",
+            geometry=original_polygon,
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=True,
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(scenario.id, mock_user_id, None)
+
+        assert len(geometries) == 1
+        geom = geometries[0]
+        assert geom.geom_type == "Polygon"
+        # Area should be approximately the same (not buffered)
+        assert abs(geom.area - original_polygon.area) < original_polygon.area * 0.01
+
+    def test_flood_geometry_from_multiple_focus_areas(self, flood_layer_type, mock_user_id):
+        """Flood geometries from multiple active focus areas should all be returned."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        flood_polygon = Polygon(
+            [
+                (-1.15, 49.95),
+                (-1.15, 50.05),
+                (-1.25, 50.05),
+                (-1.25, 49.95),
+                (-1.15, 49.95),
+            ]
+        )
+
+        flood_layer_1 = ExposureLayer.objects.create(
+            name="Flood 1",
+            geometry=flood_polygon,
+            geometry_buffered=flood_polygon,
+            type=flood_layer_type,
+        )
+        flood_layer_2 = ExposureLayer.objects.create(
+            name="Flood 2",
+            geometry=flood_polygon,
+            geometry_buffered=flood_polygon,
+            type=flood_layer_type,
+        )
+
+        focus_area_1 = FocusArea.objects.create(
+            scenario=scenario, user_id=mock_user_id, name="FA 1", is_active=True
+        )
+        focus_area_2 = FocusArea.objects.create(
+            scenario=scenario, user_id=mock_user_id, name="FA 2", is_active=True
+        )
+
+        VisibleExposureLayer.objects.create(focus_area=focus_area_1, exposure_layer=flood_layer_1)
+        VisibleExposureLayer.objects.create(focus_area=focus_area_2, exposure_layer=flood_layer_2)
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(scenario.id, mock_user_id, None)
+
+        assert len(geometries) == 2

--- a/backend/vista-python-api/src/api/tests/routing/test_graph_builder.py
+++ b/backend/vista-python-api/src/api/tests/routing/test_graph_builder.py
@@ -1,0 +1,268 @@
+"""Tests for graph builder."""
+
+import pytest
+from django.contrib.gis.geos import LineString
+
+from api.models.road_link import Directionality, OperationalState, RoadLink
+from api.routing.graph_builder import build_edge_index, build_graph_from_database, compute_data_hash
+
+
+@pytest.mark.django_db
+class TestBuildGraphFromDatabase:
+    """Tests for build_graph_from_database function."""
+
+    def test_empty_database_returns_empty_graph(self):
+        """Graph should have no nodes or edges when database is empty."""
+        G = build_graph_from_database()
+        assert G.number_of_nodes() == 0
+        assert G.number_of_edges() == 0
+
+    def test_bidirectional_road_creates_two_edges(self):
+        """Both Directions should create edges in both directions."""
+        RoadLink.objects.create(
+            osid="test-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-a",
+            end_node="node-b",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        assert G.has_edge("node-a", "node-b")
+        assert G.has_edge("node-b", "node-a")
+        assert G.number_of_edges() == 2
+
+    def test_in_direction_creates_single_edge(self):
+        """In Direction should create edge from start to end only."""
+        RoadLink.objects.create(
+            osid="test-2",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.IN_DIRECTION,
+            start_node="node-c",
+            end_node="node-d",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        assert G.has_edge("node-c", "node-d")
+        assert not G.has_edge("node-d", "node-c")
+        assert G.number_of_edges() == 1
+
+    def test_opposite_direction_creates_reverse_edge(self):
+        """In Opposite Direction should create edge from end to start only."""
+        RoadLink.objects.create(
+            osid="test-3",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.IN_OPPOSITE,
+            start_node="node-e",
+            end_node="node-f",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        assert not G.has_edge("node-e", "node-f")
+        assert G.has_edge("node-f", "node-e")
+        assert G.number_of_edges() == 1
+
+    def test_edge_attributes_include_travel_time(self):
+        """Edge should have travel_time_s calculated from length and speed."""
+        RoadLink.objects.create(
+            osid="test-4",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,  # 1km
+            directionality=Directionality.BOTH,
+            start_node="node-g",
+            end_node="node-h",
+            speed_limit_mph=60,  # ~26.8 m/s
+        )
+
+        G = build_graph_from_database()
+        edge_data = G.get_edge_data("node-g", "node-h")
+
+        assert "travel_time_s" in edge_data
+        # 1000m / (60 * 0.44704) m/s ≈ 37.3 seconds
+        assert 35 < edge_data["travel_time_s"] < 40
+
+    def test_node_coordinates_stored(self):
+        """Nodes should have x (lon) and y (lat) coordinates."""
+        RoadLink.objects.create(
+            osid="test-5",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-i",
+            end_node="node-j",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+
+        node_i_data = G.nodes["node-i"]
+        assert node_i_data["x"] == -1
+        assert node_i_data["y"] == 50
+
+        node_j_data = G.nodes["node-j"]
+        assert node_j_data["x"] == pytest.approx(-1.1)
+        assert node_j_data["y"] == pytest.approx(50.1)
+
+    def test_skips_links_without_nodes(self):
+        """Links without start_node or end_node should be skipped."""
+        RoadLink.objects.create(
+            osid="test-6",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="",  # Empty start node
+            end_node="node-k",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        assert G.number_of_nodes() == 0
+        assert G.number_of_edges() == 0
+
+    def test_skips_non_operational_roads(self):
+        """Roads that are not open should be excluded from graph."""
+        # Create an open road - should be included
+        RoadLink.objects.create(
+            osid="open-road",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-open-a",
+            end_node="node-open-b",
+            speed_limit_mph=30,
+            operational_state=OperationalState.OPEN,
+        )
+
+        # Create a closed road - should be excluded
+        RoadLink.objects.create(
+            osid="closed-road",
+            geometry=LineString([(-1.2, 50.0), (-1.3, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-closed-a",
+            end_node="node-closed-b",
+            speed_limit_mph=30,
+            operational_state=OperationalState.PERMANENTLY_CLOSED,
+        )
+
+        # Create an under-construction road - should be excluded
+        RoadLink.objects.create(
+            osid="construction-road",
+            geometry=LineString([(-1.4, 50.0), (-1.5, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-construction-a",
+            end_node="node-construction-b",
+            speed_limit_mph=30,
+            operational_state=OperationalState.UNDER_CONSTRUCTION,
+        )
+
+        G = build_graph_from_database()
+
+        # Only the open road should be in the graph
+        assert G.has_edge("node-open-a", "node-open-b")
+        assert not G.has_node("node-closed-a")
+        assert not G.has_node("node-construction-a")
+        assert G.number_of_nodes() == 2  # Only the open road's nodes
+
+    def test_includes_roads_with_empty_operational_state(self):
+        """Roads with empty operational_state should be included (legacy data)."""
+        RoadLink.objects.create(
+            osid="legacy-road",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-legacy-a",
+            end_node="node-legacy-b",
+            speed_limit_mph=30,
+            operational_state="",  # Empty - legacy data
+        )
+
+        G = build_graph_from_database()
+        assert G.has_edge("node-legacy-a", "node-legacy-b")
+
+
+@pytest.mark.django_db
+class TestComputeDataHash:
+    """Tests for compute_data_hash function."""
+
+    def test_empty_database_returns_hash(self):
+        """Should return a hash even with empty database."""
+        hash_value = compute_data_hash()
+        assert isinstance(hash_value, str)
+        assert len(hash_value) == 32  # MD5 hash length
+
+    def test_hash_changes_with_new_data(self):
+        """Hash should change when data is added."""
+        hash_before = compute_data_hash()
+
+        RoadLink.objects.create(
+            osid="test-hash-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="node-x",
+            end_node="node-y",
+            speed_limit_mph=30,
+        )
+
+        hash_after = compute_data_hash()
+        assert hash_before != hash_after
+
+
+@pytest.mark.django_db
+class TestBuildEdgeIndex:
+    """Tests for build_edge_index function."""
+
+    def test_empty_graph_returns_none_index(self):
+        """Empty graph should return (None, [], [])."""
+        G = build_graph_from_database()
+        index, keys, geoms = build_edge_index(G)
+
+        assert index is None
+        assert keys == []
+        assert geoms == []
+
+    def test_creates_strtree_with_correct_count(self):
+        """Non-empty graph should return an STRtree with correct geometry count."""
+        RoadLink.objects.create(
+            osid="idx-test-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="idx-a",
+            end_node="idx-b",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        index, keys, geoms = build_edge_index(G)
+
+        assert index is not None
+        assert len(keys) == 2  # Both directions
+        assert len(geoms) == 2
+
+    def test_returns_correct_keys_and_geoms(self):
+        """Edge keys and geometries should correspond to graph edges."""
+        RoadLink.objects.create(
+            osid="idx-test-2",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.IN_DIRECTION,
+            start_node="idx-c",
+            end_node="idx-d",
+            speed_limit_mph=30,
+        )
+
+        G = build_graph_from_database()
+        _index, keys, geoms = build_edge_index(G)
+
+        assert len(keys) == 1
+        assert keys[0] == ("idx-c", "idx-d")
+        assert geoms[0].geom_type == "LineString"

--- a/backend/vista-python-api/src/api/tests/routing/test_graph_cache.py
+++ b/backend/vista-python-api/src/api/tests/routing/test_graph_cache.py
@@ -1,0 +1,144 @@
+"""Tests for graph cache management."""
+
+import pytest
+from django.contrib.gis.geos import LineString
+
+from api.models.road_link import Directionality, RoadLink
+from api.routing import routing_cache
+
+
+@pytest.mark.django_db
+class TestGraphCache:
+    """Tests for graph cache singleton."""
+
+    def test_get_graph_lazy_initializes(self):
+        """Should lazy-initialize if accessed before explicit initialization."""
+        # Force rebuild from empty database
+        routing_cache.invalidate()
+
+        G = routing_cache.get_graph()
+        assert G is not None
+        assert G.number_of_nodes() == 0  # Empty database
+
+    def test_initialize_creates_graph(self):
+        """Initialize should create a graph instance."""
+        # Create some road data first
+        RoadLink.objects.create(
+            osid="cache-test-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="cache-a",
+            end_node="cache-b",
+            speed_limit_mph=30,
+        )
+
+        routing_cache.invalidate()
+
+        G = routing_cache.get_graph()
+        assert G is not None
+        assert G.number_of_nodes() == 2
+        assert G.number_of_edges() == 2
+
+    def test_initialize_with_empty_database(self):
+        """Initialize should work with empty database."""
+        routing_cache.invalidate()
+
+        G = routing_cache.get_graph()
+        assert G is not None
+        assert G.number_of_nodes() == 0
+        assert G.number_of_edges() == 0
+
+    def test_invalidate_rebuilds_graph(self):
+        """Invalidate should rebuild the graph."""
+        # Initialize with one road
+        RoadLink.objects.create(
+            osid="invalidate-test-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="inv-a",
+            end_node="inv-b",
+            speed_limit_mph=30,
+        )
+
+        routing_cache.invalidate()
+        original_graph = routing_cache.get_graph()
+        assert original_graph.number_of_nodes() == 2
+
+        # Add another road
+        RoadLink.objects.create(
+            osid="invalidate-test-2",
+            geometry=LineString([(-1.1, 50.1), (-1.2, 50.2)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="inv-b",
+            end_node="inv-c",
+            speed_limit_mph=30,
+        )
+
+        routing_cache.invalidate()
+        new_graph = routing_cache.get_graph()
+
+        # Should be a different object with more nodes
+        assert new_graph is not original_graph
+        assert new_graph.number_of_nodes() == 3
+
+    def test_multiple_invalidations_safe(self):
+        """Multiple invalidation calls should be safe."""
+        routing_cache.invalidate()
+        G1 = routing_cache.get_graph()
+
+        routing_cache.invalidate()
+        G2 = routing_cache.get_graph()
+
+        # Should still work, graph replaced
+        assert G1 is not None
+        assert G2 is not None
+
+
+@pytest.mark.django_db
+class TestGraphCacheEdgeIndex:
+    """Tests for edge index lifecycle in RoutingCache."""
+
+    def test_get_edge_index_lazy_initializes(self):
+        """Edge index should be built on first access."""
+        routing_cache.invalidate()
+        index, keys, geoms = routing_cache.get_edge_index()
+
+        # With empty DB, should be (None, [], [])
+        assert index is None
+        assert keys == []
+        assert geoms == []
+
+    def test_edge_index_rebuilt_on_invalidate(self):
+        """Invalidating cache should rebuild the edge index."""
+        RoadLink.objects.create(
+            osid="edge-idx-test-1",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.1)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="ei-a",
+            end_node="ei-b",
+            speed_limit_mph=30,
+        )
+
+        routing_cache.invalidate()
+        index, keys, _geoms = routing_cache.get_edge_index()
+        assert index is not None
+        assert len(keys) == 2
+
+        RoadLink.objects.create(
+            osid="edge-idx-test-2",
+            geometry=LineString([(-1.1, 50.1), (-1.2, 50.2)]),
+            length_m=1000,
+            directionality=Directionality.BOTH,
+            start_node="ei-b",
+            end_node="ei-c",
+            speed_limit_mph=30,
+        )
+
+        routing_cache.invalidate()
+        index2, keys2, _geoms2 = routing_cache.get_edge_index()
+        assert index2 is not None
+        assert len(keys2) == 4  # 2 roads x 2 directions

--- a/backend/vista-python-api/src/api/tests/routing/test_refresh_scheduler.py
+++ b/backend/vista-python-api/src/api/tests/routing/test_refresh_scheduler.py
@@ -1,0 +1,134 @@
+"""Tests for the refresh scheduler."""
+
+import threading
+from unittest.mock import Mock
+
+from api.routing.refresh_scheduler import RefreshScheduler
+
+THREAD_NAME = "routing-cache-refresh"
+
+
+def _scheduler_thread_alive() -> bool:
+    """Check if the scheduler thread is currently running."""
+    return any(t.name == THREAD_NAME for t in threading.enumerate())
+
+
+class TestRefreshScheduler:
+    """Tests for RefreshScheduler background thread management."""
+
+    def test_start_begins_background_thread(self):
+        """Starting the scheduler should create a background thread."""
+        scheduler = RefreshScheduler(
+            has_changed_fn=Mock(return_value=False),
+            rebuild_fn=Mock(),
+            interval=60,
+        )
+
+        scheduler.start()
+        try:
+            assert _scheduler_thread_alive()
+        finally:
+            scheduler.stop()
+
+    def test_stop_terminates_thread(self):
+        """Stopping the scheduler should terminate the background thread."""
+        scheduler = RefreshScheduler(
+            has_changed_fn=Mock(return_value=False),
+            rebuild_fn=Mock(),
+            interval=60,
+        )
+
+        scheduler.start()
+        assert _scheduler_thread_alive()
+
+        scheduler.stop()
+        assert not _scheduler_thread_alive()
+
+    def test_rebuild_called_when_data_changes(self):
+        """Scheduler should call rebuild_fn when has_changed_fn returns True."""
+        rebuilt = threading.Event()
+        rebuild_fn = Mock(side_effect=lambda: rebuilt.set())
+
+        scheduler = RefreshScheduler(
+            has_changed_fn=Mock(return_value=True),
+            rebuild_fn=rebuild_fn,
+            interval=0.05,
+        )
+
+        scheduler.start()
+        try:
+            rebuilt.wait(timeout=2)
+            assert rebuild_fn.called
+        finally:
+            scheduler.stop()
+
+    def test_no_rebuild_when_data_unchanged(self):
+        """Scheduler should not call rebuild_fn when has_changed_fn returns False."""
+        checked = threading.Event()
+        has_changed = Mock(return_value=False, side_effect=lambda: checked.set() or False)
+        rebuild_fn = Mock()
+
+        scheduler = RefreshScheduler(
+            has_changed_fn=has_changed,
+            rebuild_fn=rebuild_fn,
+            interval=0.05,
+        )
+
+        scheduler.start()
+        try:
+            checked.wait(timeout=2)
+            assert not rebuild_fn.called
+        finally:
+            scheduler.stop()
+
+    def test_exception_in_refresh_does_not_crash_thread(self):
+        """Exception in has_changed_fn should be logged, not crash the thread."""
+        call_count = threading.Event()
+        calls = []
+
+        def failing_check():
+            calls.append(1)
+            if len(calls) >= 2:
+                call_count.set()
+            raise RuntimeError("test error")
+
+        scheduler = RefreshScheduler(
+            has_changed_fn=failing_check,
+            rebuild_fn=Mock(),
+            interval=0.05,
+        )
+
+        scheduler.start()
+        try:
+            call_count.wait(timeout=2)
+            assert len(calls) >= 2, "Thread should survive exceptions and keep running"
+            assert _scheduler_thread_alive()
+        finally:
+            scheduler.stop()
+
+    def test_double_start_is_safe(self):
+        """Calling start() twice should not create multiple threads."""
+        scheduler = RefreshScheduler(
+            has_changed_fn=Mock(return_value=False),
+            rebuild_fn=Mock(),
+            interval=60,
+        )
+
+        scheduler.start()
+        scheduler.start()
+
+        try:
+            count = sum(1 for t in threading.enumerate() if t.name == THREAD_NAME)
+            assert count == 1
+        finally:
+            scheduler.stop()
+
+    def test_stop_without_start_is_safe(self):
+        """Calling stop() before start() should not raise."""
+        scheduler = RefreshScheduler(
+            has_changed_fn=Mock(return_value=False),
+            rebuild_fn=Mock(),
+            interval=60,
+        )
+
+        scheduler.stop()

--- a/backend/vista-python-api/src/api/tests/routing/test_route_calculator.py
+++ b/backend/vista-python-api/src/api/tests/routing/test_route_calculator.py
@@ -1,0 +1,1165 @@
+"""Tests for route calculator with constraints."""
+
+import uuid
+
+import networkx as nx
+import pytest
+from django.contrib.gis.geos import LineString, Point, Polygon
+from shapely.geometry import LineString as ShapelyLineString, box
+
+from api.models import Asset, ExposureLayer, FocusArea, Scenario, VisibleExposureLayer
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.constraint_intervention import ConstraintIntervention, ConstraintInterventionType
+from api.models.exposure_layer import ExposureLayerType
+from api.models.road_link import Directionality, RoadLink
+from api.routing import ConstraintProvider, RouteCalculator, RoutePoint, routing_cache
+from api.routing.graph_builder import build_edge_index
+
+
+class MockGraphProvider:
+    """Mock graph provider for unit testing."""
+
+    def __init__(self, graph: nx.DiGraph):  # noqa: D107
+        self._graph = graph
+        self._edge_index, self._edge_keys, self._edge_geoms = build_edge_index(graph)
+
+    def get_graph(self) -> nx.DiGraph:
+        return self._graph
+
+    def get_edge_index(self) -> tuple:
+        return self._edge_index, self._edge_keys, self._edge_geoms
+
+
+class MockConstraintProvider:
+    """Mock constraint provider for unit testing."""
+
+    def __init__(self, blocked_geometries: list | None = None):  # noqa: D107
+        self._blocked_geometries = blocked_geometries or []
+
+    def get_blocked_geometries(
+        self,
+        scenario_id=None,  # noqa: ARG002
+        user_id=None,  # noqa: ARG002
+        vehicle=None,  # noqa: ARG002
+    ):
+        return self._blocked_geometries
+
+
+def _make_geom(coords: list) -> ShapelyLineString:
+    """Create a Shapely LineString geometry for test edges."""
+    return ShapelyLineString(coords)
+
+
+@pytest.fixture
+def simple_graph():
+    """Create simple A-B-C-D test graph with geometries.
+
+    Network layout:
+        A ---- B ---- C
+               |
+               D
+    """
+    G = nx.DiGraph()
+    G.add_node("A", x=-1.0, y=50.0)
+    G.add_node("B", x=-1.1, y=50.0)
+    G.add_node("C", x=-1.2, y=50.0)
+    G.add_node("D", x=-1.1, y=49.9)
+
+    # Define edges with geometries (LineString from u to v)
+    edges = [
+        ("A", "B", "ab", [(-1.0, 50.0), (-1.1, 50.0)]),
+        ("B", "A", "ab", [(-1.1, 50.0), (-1.0, 50.0)]),
+        ("B", "C", "bc", [(-1.1, 50.0), (-1.2, 50.0)]),
+        ("C", "B", "bc", [(-1.2, 50.0), (-1.1, 50.0)]),
+        ("B", "D", "bd", [(-1.1, 50.0), (-1.1, 49.9)]),
+        ("D", "B", "bd", [(-1.1, 49.9), (-1.1, 50.0)]),
+    ]
+    for u, v, osid, coords in edges:
+        G.add_edge(u, v, travel_time_s=100, length_m=1000, osid=osid, geometry=_make_geom(coords))
+
+    return G
+
+
+class TestRouteCalculatorUnit:
+    """Unit tests for RouteCalculator using mocks."""
+
+    def test_route_between_adjacent_nodes(self, simple_graph):
+        """Should find route between adjacent nodes."""
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(simple_graph),
+            constraint_provider=MockConstraintProvider(),
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.1, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+
+    def test_route_through_multiple_nodes(self, simple_graph):
+        """Should find route through multiple nodes."""
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(simple_graph),
+            constraint_provider=MockConstraintProvider(),
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+
+    def test_no_route_returns_empty(self):
+        """Should return empty when no route exists between disconnected components."""
+        G = nx.DiGraph()
+        G.add_node("A", x=-1.0, y=50.0)
+        G.add_node("B", x=-1.1, y=50.0)
+        G.add_edge(
+            "A",
+            "B",
+            travel_time_s=100,
+            length_m=1000,
+            osid="ab",
+            geometry=_make_geom([(-1.0, 50.0), (-1.1, 50.0)]),
+        )
+        G.add_edge(
+            "B",
+            "A",
+            travel_time_s=100,
+            length_m=1000,
+            osid="ab",
+            geometry=_make_geom([(-1.1, 50.0), (-1.0, 50.0)]),
+        )
+
+        G.add_node("C", x=-1.5, y=50.5)
+        G.add_node("D", x=-1.6, y=50.5)
+        G.add_edge(
+            "C",
+            "D",
+            travel_time_s=100,
+            length_m=1000,
+            osid="cd",
+            geometry=_make_geom([(-1.5, 50.5), (-1.6, 50.5)]),
+        )
+        G.add_edge(
+            "D",
+            "C",
+            travel_time_s=100,
+            length_m=1000,
+            osid="cd",
+            geometry=_make_geom([(-1.6, 50.5), (-1.5, 50.5)]),
+        )
+
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(G),
+            constraint_provider=MockConstraintProvider(),
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.5, lat=50.5),
+        )
+
+        assert result == {
+            "type": "FeatureCollection",
+            "features": [],
+            "properties": {"hasRoute": False},
+        }
+
+    def test_same_origin_destination_returns_empty(self, simple_graph):
+        """Should return empty when origin equals destination."""
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(simple_graph),
+            constraint_provider=MockConstraintProvider(),
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.0, lat=50.0),
+        )
+
+        assert result == {
+            "type": "FeatureCollection",
+            "features": [],
+            "properties": {"hasRoute": False},
+        }
+
+    def test_blocked_edges_prevents_route(self, simple_graph):
+        """Blocked edges from constraint provider are respected."""
+        blocking_geom = box(-1.25, 49.95, -1.15, 50.05)
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(simple_graph),
+            constraint_provider=MockConstraintProvider(blocked_geometries=[blocking_geom]),
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result == {
+            "type": "FeatureCollection",
+            "features": [],
+            "properties": {"hasRoute": False},
+        }
+
+    def test_no_constraint_provider_works(self, simple_graph):
+        """Calculator should work without a constraint provider."""
+        calculator = RouteCalculator(
+            graph_provider=MockGraphProvider(simple_graph),
+            constraint_provider=None,
+        )
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+
+
+@pytest.fixture
+def simple_road_network():
+    """Create a simple road network for testing.
+
+    Network layout:
+        A ---- B ---- C
+               |
+               D
+
+    A at (-1.0, 50.0), B at (-1.1, 50.0), C at (-1.2, 50.0), D at (-1.1, 49.9)
+    """
+    RoadLink.objects.create(
+        osid="ab",
+        geometry=LineString([(-1.0, 50.0), (-1.1, 50.0)]),
+        length_m=1000,
+        directionality=Directionality.BOTH,
+        start_node="A",
+        end_node="B",
+        speed_limit_mph=30,
+    )
+    RoadLink.objects.create(
+        osid="bc",
+        geometry=LineString([(-1.1, 50.0), (-1.2, 50.0)]),
+        length_m=1000,
+        directionality=Directionality.BOTH,
+        start_node="B",
+        end_node="C",
+        speed_limit_mph=30,
+    )
+    RoadLink.objects.create(
+        osid="bd",
+        geometry=LineString([(-1.1, 50.0), (-1.1, 49.9)]),
+        length_m=1000,
+        directionality=Directionality.BOTH,
+        start_node="B",
+        end_node="D",
+        speed_limit_mph=30,
+    )
+
+
+@pytest.fixture
+def road_blocks_type():
+    """Create road blocks intervention type."""
+    return ConstraintInterventionType.objects.create(
+        id=uuid.UUID("c1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c"),
+        name="Road blocks",
+        impacts_routing=True,
+    )
+
+
+@pytest.fixture
+def flood_layer_type():
+    """Create flood exposure layer type."""
+    return ExposureLayerType.objects.create(
+        id=uuid.UUID("f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c"),
+        name="Floods",
+        impacts_exposure_score=True,
+    )
+
+
+@pytest.fixture
+def low_bridge_asset_type():
+    """Create low bridge asset type."""
+    category = AssetCategory.objects.create(id=uuid.uuid4(), name="Transport")
+    sub_category = AssetSubCategory.objects.create(
+        id=uuid.uuid4(), name="Road infrastructure", category=category
+    )
+    data_source = DataSource.objects.create(
+        id=uuid.uuid4(), name="Test Source", owner="Test", description_md="Test"
+    )
+    return AssetType.objects.create(
+        id=uuid.uuid4(),
+        name="Low bridge",
+        sub_category=sub_category,
+        data_source=data_source,
+    )
+
+
+@pytest.fixture
+def calculator():
+    """Create a RouteCalculator backed by the real routing cache."""
+    routing_cache.invalidate()
+    return RouteCalculator(
+        graph_provider=routing_cache,
+        constraint_provider=ConstraintProvider(),
+    )
+
+
+@pytest.mark.django_db
+class TestCalculateRouteIntegration:
+    """Integration tests for RouteCalculator with real database."""
+
+    @pytest.mark.usefixtures("simple_road_network")
+    def test_route_between_adjacent_nodes(self, calculator):
+        """Should find route between adjacent nodes."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.1, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) == 1
+        assert result["features"][0]["properties"]["osid"].startswith("ab")
+
+    @pytest.mark.usefixtures("simple_road_network")
+    def test_route_through_multiple_nodes(self, calculator):
+        """Should find route through multiple nodes."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+    @pytest.mark.usefixtures("db")
+    def test_no_route_raises_error_when_no_roads(self, calculator):
+        """Should raise RuntimeError when no roads exist in database."""
+        with pytest.raises(RuntimeError, match="Edge spatial index not available"):
+            calculator.calculate_route(
+                start=RoutePoint(lon=-1.0, lat=50.0),
+                end=RoutePoint(lon=-1.5, lat=50.5),
+            )
+
+    @pytest.mark.usefixtures("simple_road_network")
+    def test_route_includes_total_metrics(self, calculator):
+        """Route should include total distance and time."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert "properties" in result
+        assert "distanceMiles" in result["properties"]
+        assert "durationMinutes" in result["properties"]
+        actual_miles = result["properties"]["distanceMiles"]
+        assert 1.0 < actual_miles < 1.5, f"Expected ~1.24 miles, got {actual_miles}"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("simple_road_network")
+class TestEdgeSnappingEdgeCases:
+    """Tests for edge snapping edge cases."""
+
+    def test_same_edge_route(self, calculator):
+        """Route between two points on the same edge should work."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.03, lat=50.0),
+            end=RoutePoint(lon=-1.07, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+        assert "properties" in result
+        assert result["properties"]["distanceMiles"] > 0
+
+    def test_click_exactly_on_junction(self, calculator):
+        """Route from a junction node should work."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.1, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+    def test_very_short_route_adjacent_points(self, calculator):
+        """Very short route between nearby points should work."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.045, lat=50.0),
+            end=RoutePoint(lon=-1.055, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+    def test_route_does_not_extend_past_end_snap_point(self, calculator):
+        """Route should stop at the end snap point, not continue to the junction."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.1, lat=49.95),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        last_feature = result["features"][-1]
+        last_coords = last_feature["geometry"]["coordinates"]
+        last_point = last_coords[-1]
+        end_lat = last_point[1]
+
+        assert end_lat > 49.92, (
+            f"Route extends past end snap point to junction. "
+            f"Last coordinate lat={end_lat}, expected closer to 49.95, not 49.9 (node D)"
+        )
+
+    def test_route_with_end_closer_to_far_node(self, calculator):
+        """Route should handle end point closer to the far end of an edge."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.1, lat=49.92),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        last_feature = result["features"][-1]
+        last_coords = last_feature["geometry"]["coordinates"]
+        last_point = last_coords[-1]
+        end_lat = last_point[1]
+
+        assert abs(end_lat - 49.92) < 0.02, (
+            f"Route does not end at snap point. Last coordinate lat={end_lat}, expected ~49.92"
+        )
+
+    def test_route_with_start_closer_to_far_node(self, calculator):
+        """Route should handle start point closer to the far end of an edge."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.08, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        first_feature = result["features"][0]
+        first_coords = first_feature["geometry"]["coordinates"]
+        first_point = first_coords[0]
+        start_lon = first_point[0]
+
+        assert abs(start_lon - (-1.08)) < 0.02, (
+            f"Route does not start at snap point. First coordinate lon={start_lon}, expected ~-1.08"
+        )
+
+    def test_both_start_and_end_mid_segment(self, calculator):
+        """Route with both start and end mid-segment on different roads."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.05, lat=50.0),
+            end=RoutePoint(lon=-1.15, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        first_coords = result["features"][0]["geometry"]["coordinates"]
+        last_coords = result["features"][-1]["geometry"]["coordinates"]
+
+        start_lon = first_coords[0][0]
+        end_lon = last_coords[-1][0]
+
+        assert abs(start_lon - (-1.05)) < 0.02, f"Start not at snap: {start_lon}"
+        assert abs(end_lon - (-1.15)) < 0.02, f"End not at snap: {end_lon}"
+
+    def test_junction_route_different_edges(self, calculator):
+        """Route where start and end are on different edges meeting at same junction."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.05, lat=50.0),
+            end=RoutePoint(lon=-1.15, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        has_ab = any(osid == "ab" for osid in osids)
+        has_bc = any(osid == "bc" for osid in osids)
+
+        assert has_ab, f"Should have AB segment: {osids}"
+        assert has_bc, f"Should have BC segment: {osids}"
+
+        first_coords = result["features"][0]["geometry"]["coordinates"]
+        last_coords = result["features"][-1]["geometry"]["coordinates"]
+
+        assert abs(first_coords[0][0] - (-1.05)) < 0.02
+        assert abs(last_coords[-1][0] - (-1.15)) < 0.02
+
+    def test_same_edge_route_reversed(self, calculator):
+        """Route on same edge where start fraction > end fraction."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.07, lat=50.0),
+            end=RoutePoint(lon=-1.03, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+        assert result["properties"]["distanceMiles"] > 0
+
+    def test_multi_hop_route_with_lead_segments(self, calculator):
+        """Multi-hop route where lead segments connect snap to path."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.05, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+        osids = [f["properties"]["osid"] for f in result["features"]]
+
+        ab_edges = [osid for osid in osids if osid == "ab"]
+        bc_edges = [osid for osid in osids if osid == "bc"]
+
+        assert len(ab_edges) >= 1, f"Should have AB segment: {osids}"
+        assert len(bc_edges) >= 1, f"Should have BC segment: {osids}"
+
+        first_coords = result["features"][0]["geometry"]["coordinates"]
+        last_coords = result["features"][-1]["geometry"]["coordinates"]
+
+        start_lon = first_coords[0][0]
+        end_lon = last_coords[-1][0]
+
+        assert abs(start_lon - (-1.05)) < 0.02, f"Start not at snap: {start_lon}"
+        assert abs(end_lon - (-1.2)) < 0.02, f"End not at C: {end_lon}"
+
+    def test_route_geometry_continuity(self, calculator):
+        """Route segments should connect without gaps."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        features = result["features"]
+        assert len(features) >= 1
+
+        for i in range(len(features) - 1):
+            current_coords = features[i]["geometry"]["coordinates"]
+            next_coords = features[i + 1]["geometry"]["coordinates"]
+
+            current_end = current_coords[-1]
+            next_start = next_coords[0]
+
+            assert abs(current_end[0] - next_start[0]) < 0.0001, (
+                f"Gap between segment {i} and {i + 1}: end={current_end}, start={next_start}"
+            )
+            assert abs(current_end[1] - next_start[1]) < 0.0001, (
+                f"Gap between segment {i} and {i + 1}: end={current_end}, start={next_start}"
+            )
+
+    def test_blocked_edge_snaps_to_alternative(self, calculator, road_blocks_type, mock_user_id):
+        """When snapped edge is blocked, should find route via alternative."""
+        scenario = Scenario.objects.create(name="Test Block", is_active=False)
+        ConstraintIntervention.objects.create(
+            name="Block AB",
+            geometry=Polygon(
+                [
+                    (-1.05, 49.95),
+                    (-1.05, 50.05),
+                    (-0.95, 50.05),
+                    (-0.95, 49.95),
+                    (-1.05, 49.95),
+                ]
+            ),
+            is_active=True,
+            scenario=scenario,
+            user_id=mock_user_id,
+            type=road_blocks_type,
+        )
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        assert result["type"] == "FeatureCollection"
+        if result["features"]:
+            osids = [f["properties"]["osid"] for f in result["features"]]
+            assert not any(osid == "ab" for osid in osids)
+
+    def test_snap_distance_is_reasonable(self, calculator):
+        """Snap distance should reflect actual distance from click to road."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.05, lat=50.005),
+            end=RoutePoint(lon=-1.15, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert "properties" in result
+        assert "start" in result["properties"]
+
+        snap_feet = result["properties"]["start"]["snapDistanceFeet"]
+        assert 1000 < snap_feet < 3000, f"Snap distance {snap_feet}ft seems wrong for ~500m offset"
+
+    def test_response_includes_all_required_fields(self, calculator):
+        """Route response should include all required fields for frontend."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert "features" in result
+        assert "properties" in result
+
+        props = result["properties"]
+        assert props["hasRoute"] is True
+        assert "distanceMiles" in props
+        assert "durationMinutes" in props
+        assert "averageSpeedMph" in props
+        assert "start" in props
+        assert "end" in props
+
+        start = props["start"]
+        assert "name" in start
+        assert "requested" in start
+        assert "snapped" in start
+        assert "snapDistanceFeet" in start
+        assert "lat" in start["requested"]
+        assert "lon" in start["requested"]
+        assert "lat" in start["snapped"]
+        assert "lon" in start["snapped"]
+
+        assert len(result["features"]) >= 1
+        feature = result["features"][0]
+        assert feature["type"] == "Feature"
+        assert "properties" in feature
+        assert "geometry" in feature
+        assert "osid" in feature["properties"]
+        assert "name" in feature["properties"]
+        assert "segmentType" in feature["properties"]
+        assert feature["properties"]["segmentType"] in ("full", "trimmed", "lead", "inline")
+        assert "distanceMiles" in feature["properties"]
+        assert "durationSeconds" in feature["properties"]
+
+
+@pytest.mark.django_db
+class TestOneWayRoads:
+    """Tests for one-way road handling."""
+
+    @pytest.fixture
+    def one_way_road_network(self):
+        """Create a network with one-way roads.
+
+        Network layout:
+            A ----> B ----> C
+                    ^
+                    |
+                    D (one-way up to B)
+        """
+        RoadLink.objects.create(
+            osid="ab-oneway",
+            geometry=LineString([(-1.0, 50.0), (-1.1, 50.0)]),
+            length_m=1000,
+            directionality=Directionality.IN_DIRECTION,
+            start_node="A",
+            end_node="B",
+            speed_limit_mph=30,
+        )
+        RoadLink.objects.create(
+            osid="bc-oneway",
+            geometry=LineString([(-1.1, 50.0), (-1.2, 50.0)]),
+            length_m=1000,
+            directionality=Directionality.IN_DIRECTION,
+            start_node="B",
+            end_node="C",
+            speed_limit_mph=30,
+        )
+        RoadLink.objects.create(
+            osid="db-oneway",
+            geometry=LineString([(-1.1, 49.9), (-1.1, 50.0)]),
+            length_m=1000,
+            directionality=Directionality.IN_DIRECTION,
+            start_node="D",
+            end_node="B",
+            speed_limit_mph=30,
+        )
+
+    @pytest.mark.usefixtures("one_way_road_network")
+    def test_route_follows_one_way_direction(self, calculator):
+        """Route should follow one-way direction A→B→C."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) >= 1
+
+    @pytest.mark.usefixtures("one_way_road_network")
+    def test_no_route_against_one_way(self, calculator):
+        """Cannot route against one-way direction C→B→A."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.2, lat=50.0),
+            end=RoutePoint(lon=-1.0, lat=50.0),
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert len(result["features"]) == 0
+
+
+@pytest.mark.django_db
+class TestEmptyRoadNetwork:
+    """Tests for empty road network handling."""
+
+    def test_no_roads_raises_error(self, calculator):
+        """Route should raise RuntimeError when no roads exist in database."""
+        RoadLink.objects.all().delete()
+        routing_cache.invalidate()
+
+        with pytest.raises(RuntimeError, match="Edge spatial index not available"):
+            calculator.calculate_route(
+                start=RoutePoint(lon=-1.0, lat=50.0),
+                end=RoutePoint(lon=-1.2, lat=50.0),
+            )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("simple_road_network")
+class TestConstraintIntegration:
+    """Tests for constraint intervention integration."""
+
+    def test_polygon_constraint_blocks_route(self, calculator, road_blocks_type, mock_user_id):
+        """Route should avoid edges blocked by polygon constraint."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        ConstraintIntervention.objects.create(
+            name="Block BC",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=True,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        if result["features"]:
+            osids = [f["properties"]["osid"] for f in result["features"]]
+            assert not any(osid == "bc" for osid in osids)
+
+    def test_inactive_constraint_does_not_block(self, calculator, road_blocks_type, mock_user_id):
+        """Inactive constraints should not affect routing."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        ConstraintIntervention.objects.create(
+            name="Block BC",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=False,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+    def test_constraint_only_affects_owner(self, calculator, road_blocks_type, mock_user_id):
+        """Constraints should only affect the user who created them."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+        other_user_id = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+        ConstraintIntervention.objects.create(
+            name="Block BC",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=road_blocks_type,
+            user_id=other_user_id,
+            scenario=scenario,
+            is_active=True,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("simple_road_network")
+class TestFloodZones:
+    """Tests for flood zone handling via exposure layers."""
+
+    def test_visible_flood_layer_blocks_edges(self, calculator, flood_layer_type, mock_user_id):
+        """Visible flood layers should block intersecting edges."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        focus_area = FocusArea.objects.create(
+            scenario=scenario,
+            user_id=mock_user_id,
+            name="Test Focus Area",
+            is_active=True,
+        )
+
+        flood_layer = ExposureLayer.objects.create(
+            name="Test Flood",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            geometry_buffered=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=flood_layer_type,
+        )
+
+        VisibleExposureLayer.objects.create(
+            focus_area=focus_area,
+            exposure_layer=flood_layer,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        if result["features"]:
+            osids = [f["properties"]["osid"] for f in result["features"]]
+            assert not any(osid == "bc" for osid in osids)
+
+    def test_inactive_focus_area_flood_ignored(self, calculator, flood_layer_type, mock_user_id):
+        """Flood layers in inactive focus areas should not affect routing."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        focus_area = FocusArea.objects.create(
+            scenario=scenario,
+            user_id=mock_user_id,
+            name="Test Focus Area",
+            is_active=False,
+        )
+
+        flood_layer = ExposureLayer.objects.create(
+            name="Test Flood",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            geometry_buffered=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=flood_layer_type,
+        )
+
+        VisibleExposureLayer.objects.create(
+            focus_area=focus_area,
+            exposure_layer=flood_layer,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+    def test_non_flood_layer_type_ignored(self, calculator, mock_user_id):
+        """Non-Floods layer types should not affect routing."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        other_type = ExposureLayerType.objects.create(
+            id=uuid.uuid4(),
+            name="Coastal erosion",
+            impacts_exposure_score=True,
+        )
+
+        focus_area = FocusArea.objects.create(
+            scenario=scenario,
+            user_id=mock_user_id,
+            name="Test Focus Area",
+            is_active=True,
+        )
+
+        exposure_layer = ExposureLayer.objects.create(
+            name="Test Erosion",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            geometry_buffered=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=other_type,
+        )
+
+        VisibleExposureLayer.objects.create(
+            focus_area=focus_area,
+            exposure_layer=exposure_layer,
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            scenario_id=scenario.id,
+            user_id=mock_user_id,
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("simple_road_network")
+class TestLowBridgeRestrictions:
+    """Tests for low bridge restrictions for HGV vehicles."""
+
+    def test_hgv_blocked_near_low_bridge(self, calculator, low_bridge_asset_type):
+        """HGV routes should avoid edges near low bridges."""
+        Asset.objects.create(
+            id=uuid.uuid4(),
+            external_id="low-bridge-1",
+            name="Test Low Bridge",
+            type=low_bridge_asset_type,
+            geom=Point(-1.15, 50.0),
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            vehicle="HGV",
+        )
+
+        if result["features"]:
+            osids = [f["properties"]["osid"] for f in result["features"]]
+            assert not any(osid == "bc" for osid in osids)
+
+    def test_non_hgv_ignores_low_bridge(self, calculator, low_bridge_asset_type):
+        """Non-HGV vehicles should ignore low bridges."""
+        Asset.objects.create(
+            id=uuid.uuid4(),
+            external_id="low-bridge-2",
+            name="Test Low Bridge",
+            type=low_bridge_asset_type,
+            geom=Point(-1.15, 50.0),
+        )
+
+        routing_cache.invalidate()
+
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            vehicle="Car",
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+    def test_no_low_bridges_returns_unchanged_route(self, calculator):
+        """When no low bridges exist, HGV routing should be unchanged."""
+        result = calculator.calculate_route(
+            start=RoutePoint(lon=-1.0, lat=50.0),
+            end=RoutePoint(lon=-1.2, lat=50.0),
+            vehicle="HGV",
+        )
+
+        assert len(result["features"]) == 2
+        osids = [f["properties"]["osid"] for f in result["features"]]
+        assert any(osid == "ab" for osid in osids)
+        assert any(osid == "bc" for osid in osids)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("simple_road_network")
+class TestConstraintProviderIntegration:
+    """Integration tests for ConstraintProvider with real DB."""
+
+    def test_constraint_intervention_returns_geometries(self, road_blocks_type, mock_user_id):
+        """Constraint interventions should return blocking geometries."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        ConstraintIntervention.objects.create(
+            name="Block BC",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=True,
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(scenario.id, mock_user_id, None)
+
+        assert len(geometries) > 0
+
+    def test_inactive_constraint_returns_no_geometries(self, road_blocks_type, mock_user_id):
+        """Inactive constraints should not return geometries."""
+        scenario = Scenario.objects.create(name="Test", is_active=False)
+
+        ConstraintIntervention.objects.create(
+            name="Block BC",
+            geometry=Polygon(
+                [
+                    (-1.15, 49.95),
+                    (-1.15, 50.05),
+                    (-1.25, 50.05),
+                    (-1.25, 49.95),
+                    (-1.15, 49.95),
+                ]
+            ),
+            type=road_blocks_type,
+            user_id=mock_user_id,
+            scenario=scenario,
+            is_active=False,
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(scenario.id, mock_user_id, None)
+
+        assert len(geometries) == 0
+
+    def test_hgv_returns_bridge_geometries(self, low_bridge_asset_type):
+        """HGV vehicles should return bridge blocking geometries."""
+        Asset.objects.create(
+            id=uuid.uuid4(),
+            external_id="low-bridge-1",
+            name="Test Low Bridge",
+            type=low_bridge_asset_type,
+            geom=Point(-1.15, 50.0),
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(None, None, "HGV")
+
+        assert len(geometries) > 0
+
+    def test_non_hgv_returns_no_bridge_geometries(self, low_bridge_asset_type):
+        """Non-HGV vehicles should not return bridge geometries."""
+        Asset.objects.create(
+            id=uuid.uuid4(),
+            external_id="low-bridge-2",
+            name="Test Low Bridge",
+            type=low_bridge_asset_type,
+            geom=Point(-1.15, 50.0),
+        )
+
+        provider = ConstraintProvider()
+        geometries = provider.get_blocked_geometries(None, None, "Car")
+
+        assert len(geometries) == 0

--- a/backend/vista-python-api/src/api/tests/views/test_scenario_route.py
+++ b/backend/vista-python-api/src/api/tests/views/test_scenario_route.py
@@ -1,0 +1,146 @@
+"""Tests for the scenario route endpoint."""
+
+import uuid
+
+import pytest
+from django.contrib.gis.geos import LineString
+from rest_framework import status
+
+from api.models import Scenario
+from api.models.road_link import Directionality, RoadLink
+from api.routing import routing_cache
+
+
+@pytest.fixture
+def scenario():
+    """Create a test scenario."""
+    return Scenario.objects.create(name="Test Scenario", is_active=True)
+
+
+@pytest.fixture
+def road_network():
+    """Create a simple road network for testing routes."""
+    RoadLink.objects.create(
+        osid="link1",
+        geometry=LineString([(-1.0, 50.0), (-1.1, 50.0)], srid=4326),
+        length_m=1000,
+        directionality=Directionality.BOTH,
+        start_node="node_a",
+        end_node="node_b",
+        speed_limit_mph=30,
+        operational_state="Open",
+    )
+    RoadLink.objects.create(
+        osid="link2",
+        geometry=LineString([(-1.1, 50.0), (-1.2, 50.0)], srid=4326),
+        length_m=1000,
+        directionality=Directionality.BOTH,
+        start_node="node_b",
+        end_node="node_c",
+        speed_limit_mph=30,
+        operational_state="Open",
+    )
+    routing_cache.invalidate()
+
+
+@pytest.mark.django_db
+def test_route_nonexistent_scenario_returns_404(client):
+    """Test that requesting a route for nonexistent scenario returns 404."""
+    fake_id = uuid.uuid4()
+    response = client.post(
+        f"/api/scenarios/{fake_id}/route/",
+        data={
+            "start_lat": 50.0,
+            "start_lon": -1.0,
+            "end_lat": 50.0,
+            "end_lon": -1.2,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_route_missing_params_returns_400(scenario, client):
+    """Test that missing parameters return 400."""
+    response = client.post(
+        f"/api/scenarios/{scenario.id}/route/",
+        data={"start_lat": 50.0},
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("road_network")
+def test_route_returns_geojson(scenario, client):
+    """Test that a valid request returns GeoJSON."""
+    response = client.post(
+        f"/api/scenarios/{scenario.id}/route/",
+        data={
+            "start_lat": 50.0,
+            "start_lon": -1.0,
+            "end_lat": 50.0,
+            "end_lon": -1.2,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["type"] == "FeatureCollection"
+    assert "features" in data
+    assert "properties" in data
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("road_network")
+def test_route_with_vehicle_param(scenario, client):
+    """Test that vehicle parameter is accepted."""
+    response = client.post(
+        f"/api/scenarios/{scenario.id}/route/",
+        data={
+            "start_lat": 50.0,
+            "start_lon": -1.0,
+            "end_lat": 50.0,
+            "end_lon": -1.2,
+            "vehicle": "HGV",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_route_invalid_coordinates_returns_400(scenario, client):
+    """Latitude outside valid range should return 400."""
+    response = client.post(
+        f"/api/scenarios/{scenario.id}/route/",
+        data={
+            "start_lat": 91.0,
+            "start_lon": -1.0,
+            "end_lat": 50.0,
+            "end_lon": -1.2,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("road_network")
+def test_route_includes_runtime_seconds(scenario, client):
+    """Response properties should include runtimeSeconds."""
+    response = client.post(
+        f"/api/scenarios/{scenario.id}/route/",
+        data={
+            "start_lat": 50.0,
+            "start_lon": -1.0,
+            "end_lat": 50.0,
+            "end_lon": -1.2,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert "runtimeSeconds" in data["properties"]
+    assert isinstance(data["properties"]["runtimeSeconds"], float)

--- a/backend/vista-python-api/src/api/update_db.sh
+++ b/backend/vista-python-api/src/api/update_db.sh
@@ -2,3 +2,4 @@
 
 /venv/bin/python3 /vista-python-api/src/manage.py refresh_data
 /venv/bin/python3 /vista-python-api/src/manage.py refresh_dependency_data
+/venv/bin/python3 /vista-python-api/src/manage.py refresh_road_network

--- a/backend/vista-python-api/src/api/urls.py
+++ b/backend/vista-python-api/src/api/urls.py
@@ -118,5 +118,10 @@ urlpatterns = [
         views.ScenarioConstraintInterventionsView.as_view(),
         name="scenario-constraint-intervention-detail",
     ),
+    path(
+        "scenarios/<uuid:scenario_id>/route/",
+        views.ScenarioRouteView.as_view(),
+        name="scenario-route",
+    ),
     path("", include(router.urls)),
 ]

--- a/backend/vista-python-api/src/api/views/__init__.py
+++ b/backend/vista-python-api/src/api/views/__init__.py
@@ -15,6 +15,7 @@ from .scenario_asset_types import ScenarioAssetTypesView
 from .scenario_assets import ScenarioAssetsView
 from .scenario_constraint_interventions import ScenarioConstraintInterventionsView
 from .scenario_exposure_layers import ScenarioExposureLayersView
+from .scenario_route import ScenarioRouteView
 from .scenarios import ScenarioViewSet
 from .visible_asset_types import BulkVisibleAssetTypeView, VisibleAssetTypeView
 from .visible_exposure_layers import BulkVisibleExposureLayerView, VisibleExposureLayerView
@@ -33,6 +34,7 @@ __all__ = [
     "ScenarioAssetsView",
     "ScenarioConstraintInterventionsView",
     "ScenarioExposureLayersView",
+    "ScenarioRouteView",
     "ScenarioViewSet",
     "VisibleAssetTypeView",
     "VisibleExposureLayerView",

--- a/backend/vista-python-api/src/api/views/scenario_route.py
+++ b/backend/vista-python-api/src/api/views/scenario_route.py
@@ -1,0 +1,53 @@
+"""Views for scenario-scoped route calculation."""
+
+import time
+
+from django.shortcuts import get_object_or_404
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.models import Scenario
+from api.routing import ConstraintProvider, RouteCalculator, RoutePoint, routing_cache
+from api.serializers import RouteCalculateSerializer
+from api.utils.auth import get_user_id_from_request
+
+
+class ScenarioRouteView(APIView):
+    """View for calculating routes within a scenario context."""
+
+    def post(self, request, scenario_id):
+        """Calculate a route with scenario constraints applied."""
+        start_time = time.time()
+
+        scenario = get_object_or_404(Scenario, id=scenario_id)
+        user_id = get_user_id_from_request(request)
+
+        serializer = RouteCalculateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        start = RoutePoint(
+            lon=serializer.validated_data["start_lon"],
+            lat=serializer.validated_data["start_lat"],
+        )
+        end = RoutePoint(
+            lon=serializer.validated_data["end_lon"],
+            lat=serializer.validated_data["end_lat"],
+        )
+
+        calculator = RouteCalculator(
+            graph_provider=routing_cache,
+            constraint_provider=ConstraintProvider(),
+        )
+        route_geojson = calculator.calculate_route(
+            start=start,
+            end=end,
+            scenario_id=scenario.id,
+            user_id=user_id,
+            vehicle=serializer.validated_data.get("vehicle"),
+        )
+
+        runtime_seconds = round(time.time() - start_time, 4)
+        if "properties" in route_geojson:
+            route_geojson["properties"]["runtimeSeconds"] = runtime_seconds
+
+        return Response(route_geojson)

--- a/backend/vista-python-api/src/core/wsgi.py
+++ b/backend/vista-python-api/src/core/wsgi.py
@@ -7,6 +7,7 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
 """
 
+import logging
 import os
 
 from django.core.wsgi import get_wsgi_application
@@ -14,3 +15,12 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
 
 application = get_wsgi_application()
+
+# Initialize routing cache after Django is fully loaded.
+logger = logging.getLogger(__name__)
+try:
+    from api.routing import routing_cache
+
+    routing_cache.initialize()
+except Exception:
+    logger.exception("Failed to initialize routing cache on startup")


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

https://ndtp.atlassian.net/browse/DPAV-2300

## Description

Port of the vista-asset-scores astar routing
- RoadLink model backed by OS NGD data via new refresh_road_network command
- A* pathfinding with edge snapping for accurate mid-segment routing
- Constraint blocking from scenario data, active floods, low bridges and constraint interventions
- Graph built at startup and cached, polls the table for updates to handle data updates
- New scenario-scoped route endpoint POST scenarios/<uuid>/route/


## How Has This Been Tested?

Locally & unit tests

Request 
```json
{"startLat":50.70238511030314,"startLon":-1.2916915245514247,"endLat":50.70040232942375,"endLon":-1.2937505223484607,"vehicle":"HGV"}
```

Response
```json
{
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "properties": {
                "osid": "4dbec5b7-aa0b-4807-b1b5-84910d515298",
                "name": "Little London",
                "segmentType": "trimmed",
                "distanceMiles": 0.0243,
                "durationSeconds": 2.9174123120973516,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2923371,
                        50.7020762
                    ],
                    [
                        -1.2924096,
                        50.701993
                    ],
                    [
                        -1.2926052,
                        50.7017683
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "f8328e6e-c05d-4a37-a968-aeed1407f3b6",
                "name": "Sea Street",
                "segmentType": "full",
                "distanceMiles": 0.0255,
                "durationSeconds": 3.06370794559771,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2931406,
                        50.7018975
                    ],
                    [
                        -1.2930847,
                        50.7018971
                    ],
                    [
                        -1.2929152,
                        50.7018691
                    ],
                    [
                        -1.2928164,
                        50.7018505
                    ],
                    [
                        -1.2926052,
                        50.7017683
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "8c4c8b43-19df-41bf-a86a-456c12a2a4c4",
                "name": "Sea Street",
                "segmentType": "full",
                "distanceMiles": 0.0308,
                "durationSeconds": 3.6981776425674067,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2938361,
                        50.7018388
                    ],
                    [
                        -1.2935771,
                        50.7018585
                    ],
                    [
                        -1.2933399,
                        50.7018765
                    ],
                    [
                        -1.2931697,
                        50.7018977
                    ],
                    [
                        -1.2931406,
                        50.7018975
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "f8dda55b-a4a1-4edb-bd15-f0b61c7307b7",
                "name": "Holyrood Street",
                "segmentType": "full",
                "distanceMiles": 0.0137,
                "durationSeconds": 1.6404199475065617,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2938361,
                        50.7018388
                    ],
                    [
                        -1.2938391,
                        50.7016409
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "1365152b-8cc3-4f63-b171-7d7febd6b257",
                "name": "Holyrood Street",
                "segmentType": "full",
                "distanceMiles": 0.0186,
                "durationSeconds": 2.2261989978525416,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2938391,
                        50.7016409
                    ],
                    [
                        -1.2938431,
                        50.7013725
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "6ce6691f-75ff-42ab-a3cf-58d5da3b2621",
                "name": "Holyrood Street",
                "segmentType": "full",
                "distanceMiles": 0.028,
                "durationSeconds": 3.3606985206394655,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2938431,
                        50.7013725
                    ],
                    [
                        -1.2938491,
                        50.7009755
                    ],
                    [
                        -1.293849,
                        50.7009672
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "730bd18a-7aeb-43e1-b32f-fa6a75369ec5",
                "name": "Holyrood Street",
                "segmentType": "full",
                "distanceMiles": 0.0195,
                "durationSeconds": 2.3448311858744932,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.293849,
                        50.7009672
                    ],
                    [
                        -1.2938446,
                        50.7009163
                    ],
                    [
                        -1.2938374,
                        50.7008136
                    ],
                    [
                        -1.2938246,
                        50.7007236
                    ],
                    [
                        -1.2938173,
                        50.7006853
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "e91ea1e1-cefe-4785-a734-8e08bd6a759c",
                "name": "Holyrood Street",
                "segmentType": "full",
                "distanceMiles": 0.0117,
                "durationSeconds": 1.4092698639942733,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2938173,
                        50.7006853
                    ],
                    [
                        -1.2937869,
                        50.7005254
                    ],
                    [
                        -1.2937852,
                        50.7005165
                    ]
                ]
            }
        },
        {
            "type": "Feature",
            "properties": {
                "osid": "0eaa90d9-d9f7-4122-ae77-afbfd32179f7",
                "name": "Holyrood Street",
                "segmentType": "lead",
                "distanceMiles": 0.0052,
                "durationSeconds": 0.6243523523116192,
                "speedMph": 30.0
            },
            "geometry": {
                "type": "LineString",
                "coordinates": [
                    [
                        -1.2937852,
                        50.7005165
                    ],
                    [
                        -1.293739825236091,
                        50.70040675209542
                    ]
                ]
            }
        }
    ],
    "properties": {
        "hasRoute": true,
        "distanceMiles": 0.18,
        "durationMinutes": 0.4,
        "averageSpeedMph": 30.0,
        "start": {
            "name": "Little London",
            "requested": {
                "lat": 50.70238511030314,
                "lon": -1.2916915245514247
            },
            "snapped": {
                "lat": 50.7020762,
                "lon": -1.2923371
            },
            "snapDistanceFeet": 165.5
        },
        "end": {
            "name": "Holyrood Street",
            "requested": {
                "lat": 50.70040232942375,
                "lon": -1.2937505223484607
            },
            "snapped": {
                "lat": 50.70040675209542,
                "lon": -1.293739825236091
            },
            "snapDistanceFeet": 2.7
        },
        "runtimeSeconds": 0.3822
    }
}
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
