### PR TITLE
feature: [DPAV-2386] filter data user has no access to

### DIFF
--- a/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
+++ b/backend/vista-python-api/src/api/tests/views/test_scenario_assets.py
@@ -13,6 +13,9 @@ from api.models import (
     ExposureLayer,
     ExposureLayerType,
     FocusArea,
+    Group,
+    GroupDataSourceAccess,
+    GroupMembership,
     Scenario,
     ScenarioAsset,
     VisibleAsset,
@@ -24,6 +27,13 @@ from api.tests.conftest import buffer_geometry
 
 http_success_code = 200
 http_not_found = 404
+
+user_id_limited_access = uuid.uuid4()
+
+
+def get_user_id_from_request(request):  # noqa: ARG001
+    """Mock user ID in request."""
+    return user_id_limited_access
 
 
 def print_sql(test_name: str, queries: list[dict]) -> None:
@@ -89,24 +99,40 @@ def scenario_assets(scenario, asset_type_setup):
 
 
 @pytest.fixture
-def asset_types_for_scenario(db):  # noqa: ARG001
+def limited_rail_data_source(db):  # noqa: ARG001
+    """Create data source intended for limited access use cases."""
+    return DataSource.objects.create(id=uuid.uuid4(), name="Test Source")
+
+
+@pytest.fixture
+def data_source_access(db, limited_rail_data_source):  # noqa: ARG001
+    """Create access to data source."""
+    group = Group.objects.create(name="Limited Access", created_by=uuid.uuid4())
+    GroupMembership.objects.create(
+        group=group, user_id=user_id_limited_access, created_by=uuid.uuid4()
+    )
+    return GroupDataSourceAccess.objects.create(data_source=limited_rail_data_source, group=group)
+
+
+@pytest.fixture
+def asset_types_for_scenario(db, limited_rail_data_source):  # noqa: ARG001
     """Create asset types for testing."""
     category = AssetCategory.objects.create(id=uuid.uuid4(), name="Test Category")
     sub_category = AssetSubCategory.objects.create(
         id=uuid.uuid4(), name="Test SubCategory", category=category
     )
-    data_source = DataSource.objects.create(id=uuid.uuid4(), name="Test Source")
     rail_type = AssetType.objects.create(
         id=uuid.uuid4(),
         name="Rail Stations",
         sub_category=sub_category,
-        data_source=data_source,
+        data_source=limited_rail_data_source,
     )
+    hospital_data_source = DataSource.objects.create(id=uuid.uuid4(), name="Test Source")
     hospital_type = AssetType.objects.create(
         id=uuid.uuid4(),
         name="Hospitals",
         sub_category=sub_category,
-        data_source=data_source,
+        data_source=hospital_data_source,
     )
     return {"rail": rail_type, "hospital": hospital_type}
 
@@ -647,6 +673,48 @@ def test_asset_types_map_wide_returns_all(
 
 
 @pytest.mark.django_db
+def test_asset_types_map_wide_does_not_include_data_source_user_cannot_access(  # noqa: PLR0913
+    scenario,
+    limited_rail_data_source,  # noqa: ARG001
+    asset_types_for_scenario,  # noqa: ARG001
+    assets_for_scenario,  # noqa: ARG001
+    data_source_access,  # noqa: ARG001
+    client,
+):
+    """Test only asset types user has access to are returned."""
+    response = client.get(f"/api/scenarios/{scenario.id}/asset-types/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    assert "Rail Stations" not in names
+    assert "Hospitals" in names
+
+
+@pytest.mark.django_db
+def test_asset_types_map_wide_includes_data_source_user_can_access_via_group(  # noqa: PLR0913
+    scenario,
+    limited_rail_data_source,  # noqa: ARG001
+    asset_types_for_scenario,  # noqa: ARG001
+    assets_for_scenario,  # noqa: ARG001
+    data_source_access,  # noqa: ARG001
+    client,
+    monkeypatch,
+):
+    """Test only asset types user has access to are returned."""
+    monkeypatch.setattr(
+        "api.views.scenario_asset_types.get_user_id_from_request", get_user_id_from_request
+    )
+    response = client.get(f"/api/scenarios/{scenario.id}/asset-types/")
+    data = response.json()
+
+    assert response.status_code == http_success_code
+    names = get_all_asset_type_names(data)
+    assert "Rail Stations" in names
+    assert "Hospitals" in names
+
+
+@pytest.mark.django_db
 def test_asset_types_includes_datasource_id(
     scenario,
     asset_types_for_scenario,  # noqa: ARG001
@@ -723,7 +791,6 @@ def test_asset_types_focus_area_returns_both_when_assets_in_area(
     assert "Hospitals" in names
 
 
-@pytest.mark.django_db
 @pytest.mark.django_db
 def test_asset_types_focus_area_invalid_returns_404(scenario, client):
     """Test that invalid focus_area_id returns 404."""

--- a/backend/vista-python-api/src/api/views/scenario_asset_types.py
+++ b/backend/vista-python-api/src/api/views/scenario_asset_types.py
@@ -2,14 +2,14 @@
 
 from uuid import UUID
 
-from django.db.models import Count, Q
+from django.db.models import Count, Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from api.filters import AssetFilterBuilder, FilterContext
 from api.filters.asset_filter import has_criteria
-from api.models import AssetScoreFilter, FocusArea, Scenario, VisibleAsset
+from api.models import AssetScoreFilter, FocusArea, GroupDataSourceAccess, Scenario, VisibleAsset
 from api.models.asset import Asset
 from api.models.asset_type import AssetType
 from api.utils.auth import get_user_id_from_request
@@ -97,28 +97,50 @@ class ScenarioAssetTypesView(APIView):
         builder = AssetFilterBuilder(ctx)
 
         focus_area = None
-        asset_types_q = AssetType.objects.select_related("sub_category__category", "data_source")
         if focus_area_id:
             focus_area = get_object_or_404(
                 FocusArea, id=focus_area_id, scenario_id=scenario_id, user_id=user_id
             )
 
-        if focus_area and focus_area.geometry:
-            asset_types_q = asset_types_q.annotate(
-                asset_count_in_focus_area=Count(
-                    "assets", filter=Q(assets__geom__within=focus_area.geometry), distinct=True
-                ),
-                asset_count_total=Count("assets", distinct=True),
-            )
-        else:
-            asset_types_q = asset_types_q.annotate(
-                asset_count_in_focus_area=Count("assets", distinct=True),
-                asset_count_total=Count("assets", distinct=True),
-            )
-
+        asset_types_q = self._get_initial_asset_type_query(user_id)
+        asset_types_q = self._update_asset_type_query_with_counts(focus_area, asset_types_q)
         asset_types = asset_types_q.order_by(
             "sub_category__category__name", "sub_category__name", "name"
         )
 
         result = _build_categories_response(asset_types, visible_type_ids, builder, focus_area)
         return Response(result)
+
+    def _get_initial_asset_type_query(self, user_id):
+        """Fetch asset type query filtering based on group access."""
+        data_source_has_any_group_access = GroupDataSourceAccess.objects.filter(
+            data_source=OuterRef("data_source")
+        )
+
+        data_source_has_user_membership = GroupDataSourceAccess.objects.filter(
+            data_source=OuterRef("data_source"),
+            group__members__user_id=user_id,
+        )
+
+        return (
+            AssetType.objects.select_related("sub_category__category", "data_source")
+            .annotate(
+                has_any_group_access=Exists(data_source_has_any_group_access),
+                has_user_membership=Exists(data_source_has_user_membership),
+            )
+            .filter(Q(has_any_group_access=False) | Q(has_user_membership=True))
+        )
+
+    def _update_asset_type_query_with_counts(self, focus_area, asset_types_q):
+        """Update asset type query with annotations for counts of assets."""
+        if focus_area and focus_area.geometry:
+            return asset_types_q.annotate(
+                asset_count_in_focus_area=Count(
+                    "assets", filter=Q(assets__geom__within=focus_area.geometry), distinct=True
+                ),
+                asset_count_total=Count("assets", distinct=True),
+            )
+        return asset_types_q.annotate(
+            asset_count_in_focus_area=Count("assets", distinct=True),
+            asset_count_total=Count("assets", distinct=True),
+        )


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Access to data sources is controlled via groups. A user is allowed access to the data via two mechanisms:
1. The data is globally available, so there are no groups that have been given specific access.
2. The user is a member of a group that has been given access to the data.

## Description
Filter out any asset types associated with a data source that (a) has associated `groupdatasourceaccess` records and (b) the user is not a member of any groups associated with the linked `groupdatasourceaccess` records.

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Manually and via unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
