### PR TITLE
feat(DPAV-2545): remove VisibleExposureLayers from published when revoked

### DIFF
--- a/backend/vista-python-api/src/api/tests/views/test_user_exposure_layers.py
+++ b/backend/vista-python-api/src/api/tests/views/test_user_exposure_layers.py
@@ -1728,3 +1728,54 @@ def test_bulk_toggle_other_users_approved_layers_by_type(
     assert VisibleExposureLayer.objects.filter(
         focus_area=focus_area, exposure_layer=other_approved
     ).exists()
+
+
+@pytest.mark.django_db
+def test_remove_cleans_up_non_owner_visibility_records(
+    scenario, mock_user_id, user_drawn_type, client
+):
+    """Test that removing a layer removes visibility records for non-owners."""
+    owner_id = uuid.uuid4()
+    layer = ExposureLayer.objects.create(
+        name="Approved Layer",
+        geometry=GEOSGeometry("POLYGON((0.2 0.2, 0.2 0.3, 0.3 0.3, 0.3 0.2, 0.2 0.2))"),
+        geometry_buffered=buffer_geometry(
+            GEOSGeometry("POLYGON((0.2 0.2, 0.2 0.3, 0.3 0.3, 0.3 0.2, 0.2 0.2))")
+        ),
+        type=user_drawn_type,
+        user_id=owner_id,
+        scenario=scenario,
+        status=ExposureLayer.APPROVED,
+    )
+
+    owner_focus_area = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=owner_id,
+        name="Owner Area",
+        geometry=GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"),
+        filter_mode="by_asset_type",
+        is_active=True,
+        is_system=False,
+    )
+    other_focus_area = FocusArea.objects.create(
+        scenario=scenario,
+        user_id=mock_user_id,
+        name="Other Area",
+        geometry=GEOSGeometry("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"),
+        filter_mode="by_asset_type",
+        is_active=True,
+        is_system=False,
+    )
+
+    VisibleExposureLayer.objects.create(focus_area=owner_focus_area, exposure_layer=layer)
+    VisibleExposureLayer.objects.create(focus_area=other_focus_area, exposure_layer=layer)
+
+    response = client.post(f"/api/scenarios/{scenario.id}/exposure-layers/{layer.id}/remove/")
+    assert response.status_code == http_ok
+
+    assert VisibleExposureLayer.objects.filter(
+        focus_area=owner_focus_area, exposure_layer=layer
+    ).exists()
+    assert not VisibleExposureLayer.objects.filter(
+        focus_area=other_focus_area, exposure_layer=layer
+    ).exists()

--- a/backend/vista-python-api/src/api/views/scenario_exposure_layers.py
+++ b/backend/vista-python-api/src/api/views/scenario_exposure_layers.py
@@ -2,7 +2,7 @@
 
 import json
 
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import Case, CharField, F, Prefetch, Q, Value, When
 from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
@@ -403,7 +403,15 @@ class ScenarioExposureLayersView(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        exposure_layer.status = ExposureLayer.UNPUBLISHED
-        exposure_layer.removed_by = user_id
-        exposure_layer.save()
+        with transaction.atomic():
+            exposure_layer.status = ExposureLayer.UNPUBLISHED
+            exposure_layer.removed_by = user_id
+            exposure_layer.save()
+
+            VisibleExposureLayer.objects.filter(
+                exposure_layer=exposure_layer,
+            ).exclude(
+                focus_area__user_id=exposure_layer.user_id,
+            ).delete()
+
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
https://ndtp.atlassian.net/browse/DPAV-2544

When an admin removes a published exposure layer users could be using it so we must clean up other users references to it when removing, otherwise they will be counted towards the exposure score even though they are no longer visible.


## Description

Cleanup VisibleExposureLayers from other users when its revoked

## How Has This Been Tested?

Locally & unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
