### PR TITLE
bugfix: [DPAV-2387] automatically log user out on removal from vista

### DIFF
--- a/.github/workflows/backend-ci-pr.yml
+++ b/.github/workflows/backend-ci-pr.yml
@@ -271,7 +271,7 @@ jobs:
       - name: Ping App
         run: |
           #!/bin/bash
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/ping/)
+          status_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health/)
           if [[ "$status_code" == "200" ]]; then
             echo "Ping successful (200 OK)"  >> $GITHUB_STEP_SUMMARY
           else

--- a/backend/vista-python-api/src/api/tests/utils/test_auth.py
+++ b/backend/vista-python-api/src/api/tests/utils/test_auth.py
@@ -11,6 +11,7 @@ from api.utils.auth import (
     generate_temp_password,
     get_user_id_from_request,
     get_user_is_admin_from_request,
+    is_user_authenticated,
 )
 
 
@@ -45,6 +46,12 @@ def _base_token(user_id, groups):
         "exp": 9999999999,
         "iat": 1700000000,
     }
+
+
+@pytest.fixture
+def valid_token_no_access(user_id):
+    """Create a valid JWT token without Cognito claims."""
+    return _create_jwt(_base_token(user_id, []))
 
 
 @pytest.fixture
@@ -160,6 +167,67 @@ class TestGetUserIsAdminFromRequest:
 
         with pytest.raises(AuthenticationFailed, match="Invalid token format"):
             get_user_is_admin_from_request(request)
+
+
+class TestIsUserAuthenticated:
+    """Tests for is_user_authenticated function."""
+
+    def test_returns_true_in_dev_mode(self, settings):
+        """In development mode, returns true."""
+        settings.IS_PROD = False
+        request = MockRequest()
+
+        result = is_user_authenticated(request)
+
+        assert result
+
+    def test_returns_true_if_user_has_required_claim(self, settings, valid_token, user_id):  # noqa: ARG002
+        """Returns true if user has required claim from a valid JWT token."""
+        settings.IS_PROD = True
+        request = MockRequest({"X-Auth-Request-Access-Token": valid_token})
+
+        result = is_user_authenticated(request)
+
+        assert result
+
+    def test_returns_false_if_user_does_not_have_required_claims(
+        self,
+        settings,
+        valid_token_no_access,
+        user_id,  # noqa: ARG002
+    ):
+        """Returns true if user has required claim from a valid JWT token."""
+        settings.IS_PROD = True
+        request = MockRequest({"X-Auth-Request-Access-Token": valid_token_no_access})
+
+        result = is_user_authenticated(request)
+
+        assert not result
+
+    def test_raises_error_when_token_missing(self, settings):
+        """Raises AuthenticationFailed when token header is missing."""
+        settings.IS_PROD = True
+        request = MockRequest()
+
+        with pytest.raises(AuthenticationFailed, match="Missing X-Auth-Request-Access-Token"):
+            is_user_authenticated(request)
+
+    def test_raises_error_for_malformed_token(self, settings):
+        """Raises AuthenticationFailed when token is not a valid JWT."""
+        settings.IS_PROD = True
+        request = MockRequest({"X-Auth-Request-Access-Token": "not-a-jwt"})
+
+        with pytest.raises(AuthenticationFailed, match="Invalid token format"):
+            is_user_authenticated(request)
+
+    def test_raises_error_when_sub_claim_missing(self, settings):
+        """Raises AuthenticationFailed when sub claim is not in token."""
+        settings.IS_PROD = True
+        token = _create_jwt({"exp": 9999999999})
+        request = MockRequest({"X-Auth-Request-Access-Token": token})
+
+        with pytest.raises(AuthenticationFailed, match="Invalid token format"):
+            is_user_authenticated(request)
 
 
 def test_generate_temp_password():

--- a/backend/vista-python-api/src/api/utils/auth.py
+++ b/backend/vista-python-api/src/api/utils/auth.py
@@ -55,6 +55,34 @@ def get_user_id_from_request(request) -> uuid.UUID:
         raise AuthenticationFailed(f"Invalid token format: {e}") from e
 
 
+def is_user_authenticated(request) -> bool:
+    """
+    Determine whether the user is authenticated.
+
+    The token is already validated by the gateway (Istio), so we just
+    decode the JWT payload to extract the subject claim.
+
+    In development, returns true.
+
+    Args:
+        request: The HTTP request object
+
+    Returns:
+        boolean: true if user is authenticated
+
+    Raises:
+        AuthenticationFailed: If user is not authenticated
+    """
+    if not settings.IS_PROD:
+        return True
+    jwt = _validate_header_fetch_jwt(request)
+    token = _decode_jwt(jwt)
+    try:
+        return "vista_access" in token["cognito:groups"]
+    except (IndexError, KeyError, ValueError) as e:
+        raise AuthenticationFailed(f"Invalid token format: {e}") from e
+
+
 def get_user_is_admin_from_request(request) -> bool:
     """
     Extract whether the user is an admin from the authentication token.

--- a/backend/vista-python-api/src/core/tests/test_views.py
+++ b/backend/vista-python-api/src/core/tests/test_views.py
@@ -5,6 +5,29 @@ from __future__ import annotations
 from django.urls import reverse
 
 
-def test_ping(client):
+def is_user_authenticated_true(request):  # noqa: ARG001
+    """Mock that a user is authenticated."""
+    return True
+
+
+def is_user_authenticated_false(request):  # noqa: ARG001
+    """Mock that a user is not authenticated."""
+    return False
+
+
+def test_ping_returns_200_user_authenticated(client, monkeypatch):
     """Test ping."""
+    monkeypatch.setattr("core.views.is_user_authenticated", is_user_authenticated_true)
     assert client.get(reverse("ping")).content == b"OK"
+
+
+def test_ping_returns_403_forbidden_user_not_authenticated(client, monkeypatch):
+    """Test ping."""
+    monkeypatch.setattr("core.views.is_user_authenticated", is_user_authenticated_false)
+    response = client.get(reverse("ping"))
+    assert response.status_code == 403
+
+
+def test_health(client):
+    """Test health."""
+    assert client.get(reverse("health")).content == b"OK"

--- a/backend/vista-python-api/src/core/urls.py
+++ b/backend/vista-python-api/src/core/urls.py
@@ -18,10 +18,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
-from core.views import ping
+from core.views import health, ping
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("api.urls")),
+    path("health/", health, name="health"),
     path("ping/", ping, name="ping"),
 ]

--- a/backend/vista-python-api/src/core/views.py
+++ b/backend/vista-python-api/src/core/views.py
@@ -1,10 +1,20 @@
 """Core views for system use."""
 
+from api.utils.auth import is_user_authenticated
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.views.decorators.http import require_http_methods
 
 
 @require_http_methods(["GET", "HEAD"])
-def ping(_request):
-    """Confirm that we are up and that the user has been able to access us."""
+def ping(request):
+    """Confirm that a user is able to access us if authenticated."""
+    if is_user_authenticated(request):
+        return HttpResponse("OK", content_type="text/plain")
+    raise PermissionDenied
+
+
+@require_http_methods(["GET", "HEAD"])
+def health(_request):
+    """Confirm that we are up and healthy."""
     return HttpResponse("OK", content_type="text/plain")


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to pre-empt the end of a user's active session if they have been removed from VISTA.

## Description
1. Alter current simple ping endpoint -> `health` (allows for CI to check app is up)
2. Include an authentication check in the `/ping` endpoint (will cause a log out when 403 returned from API)

<!--- Describe your changes in detail -->

## How Has This Been Tested?
Unit tests and manually flipping the dev stub over to False while running VISTA.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
