### PR TITLE
bugfix(DPAV-2386): Disable save button when no groups are selected

### DIFF
--- a/frontend/src/pages/DataSourceDetail.tsx
+++ b/frontend/src/pages/DataSourceDetail.tsx
@@ -105,6 +105,8 @@ export default function DataSourceDetail() {
         return false;
     }, [availability, currentGroupIds, data, selectedGroupIds]);
 
+    const isValid = availability === 'yes' || selectedGroupIds.size > 0;
+
     const handleToggleGroup = (groupId: string) => {
         setSelectedGroupIds((prev) => {
             const next = new Set(prev);
@@ -319,7 +321,7 @@ export default function DataSourceDetail() {
                                 <Button variant="outlined" onClick={handleCancel} disabled={isSaving}>
                                     CANCEL
                                 </Button>
-                                <Button variant="contained" onClick={handleSave} disabled={isSaving || !isDirty}>
+                                <Button variant="contained" onClick={handleSave} disabled={isSaving || !isDirty || !isValid}>
                                     SAVE
                                 </Button>
                             </Box>

--- a/frontend/src/pages/DataSourcesDetail.test.tsx
+++ b/frontend/src/pages/DataSourcesDetail.test.tsx
@@ -101,6 +101,17 @@ describe('DataSourceDetail', () => {
         expect(screen.getByPlaceholderText('Search for group')).toBeInTheDocument();
     });
 
+    it('disables save when restricted mode is chosen but no groups are selected', async () => {
+        const dataSource = mockDataSources[0];
+        mockedFetchDataSource.mockResolvedValue(dataSource);
+        renderWithAppProviders([`/data-room/data-source/${dataSource.id}`]);
+
+        fireEvent.click(await screen.findByRole('radio', { name: 'No' }));
+
+        const saveButton = screen.getByRole('button', { name: 'SAVE' });
+        expect(saveButton).toBeDisabled();
+    });
+
     it('saves selected group access when restricted mode is chosen', async () => {
         const dataSource = mockDataSources[0];
         mockedFetchDataSource.mockResolvedValue(dataSource);


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

Avoid confusing UI

## Description

At-least one group must exist for it to limit the datasource, otherwise
it will still be available to all as DataSource has no flag its status
is determined by the existance of at-least one GroupDataSourceAccess record.

## How Has This Been Tested?

Locally & unit test

## Screenshots (if appropriate):
<img width="902" height="529" alt="Screenshot 2026-02-25 at 12 37 54" src="https://github.com/user-attachments/assets/34b06b21-4f2a-444c-9b08-32c56e480b42" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [ ] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
