### PR TITLE
fix: clean up stale VisibleAsset records when data source access changes

### DIFF
--- a/backend/vista-python-api/src/api/services/data_source_access_service.py
+++ b/backend/vista-python-api/src/api/services/data_source_access_service.py
@@ -2,7 +2,7 @@
 
 from django.db.models import Exists, OuterRef, Q
 
-from api.models import Asset, AssetType, GroupDataSourceAccess
+from api.models import Asset, AssetType, GroupDataSourceAccess, VisibleAsset
 
 
 def user_can_access_asset(user_id, asset: Asset) -> bool:
@@ -43,3 +43,24 @@ def _get_data_source_has_user_membership(user_id):
         data_source=OuterRef("data_source"),
         group__members__user_id=user_id,
     )
+
+
+def cleanup_stale_visible_assets(user_ids):
+    """Remove VisibleAsset records for asset types the given users can no longer access."""
+    if not user_ids:
+        return 0
+
+    data_source_is_restricted = GroupDataSourceAccess.objects.filter(
+        data_source=OuterRef("asset_type__data_source"),
+    )
+    user_has_access = GroupDataSourceAccess.objects.filter(
+        data_source=OuterRef("asset_type__data_source"),
+        group__members__user_id=OuterRef("focus_area__user_id"),
+    )
+    deleted_count, _ = (
+        VisibleAsset.objects.filter(focus_area__user_id__in=user_ids)
+        .filter(Exists(data_source_is_restricted))
+        .exclude(Exists(user_has_access))
+        .delete()
+    )
+    return deleted_count

--- a/backend/vista-python-api/src/api/tests/services/__init__.py
+++ b/backend/vista-python-api/src/api/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for service modules."""

--- a/backend/vista-python-api/src/api/tests/services/test_data_source_access_service.py
+++ b/backend/vista-python-api/src/api/tests/services/test_data_source_access_service.py
@@ -1,0 +1,244 @@
+"""Tests for the data source access service."""
+
+import uuid
+
+import pytest
+
+from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.group import Group, GroupDataSourceAccess, GroupMembership
+from api.services.data_source_access_service import cleanup_stale_visible_assets
+
+
+@pytest.fixture
+def scenario(db):  # noqa: ARG001
+    """Create test scenario."""
+    return Scenario.objects.create(name="Test Scenario", is_active=True)
+
+
+@pytest.fixture
+def user_id():
+    """Return a test user ID."""
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def other_user_id():
+    """Return another test user ID."""
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def focus_area(scenario, user_id):
+    """Create a focus area for the test user."""
+    return FocusArea.objects.create(
+        scenario=scenario,
+        user_id=user_id,
+        name="Map-wide",
+        is_system=True,
+    )
+
+
+@pytest.fixture
+def other_focus_area(scenario, other_user_id):
+    """Create a focus area for another user."""
+    return FocusArea.objects.create(
+        scenario=scenario,
+        user_id=other_user_id,
+        name="Map-wide",
+        is_system=True,
+    )
+
+
+@pytest.fixture
+def data_source(db):  # noqa: ARG001
+    """Create a data source."""
+    return DataSource.objects.create(name="Restricted DS", owner="Test", description_md="")
+
+
+@pytest.fixture
+def global_data_source(db):  # noqa: ARG001
+    """Create a globally available data source (no group access records)."""
+    return DataSource.objects.create(name="Global DS", owner="Test", description_md="")
+
+
+@pytest.fixture
+def category(db):  # noqa: ARG001
+    """Create an asset category."""
+    return AssetCategory.objects.create(name="Infrastructure")
+
+
+@pytest.fixture
+def sub_category(category):
+    """Create an asset sub-category."""
+    return AssetSubCategory.objects.create(name="Transport", category=category)
+
+
+@pytest.fixture
+def restricted_asset_type(sub_category, data_source):
+    """Create an asset type linked to a restricted data source."""
+    return AssetType.objects.create(
+        name="Rail Stations",
+        sub_category=sub_category,
+        data_source=data_source,
+    )
+
+
+@pytest.fixture
+def global_asset_type(sub_category, global_data_source):
+    """Create an asset type linked to a globally available data source."""
+    return AssetType.objects.create(
+        name="Roads",
+        sub_category=sub_category,
+        data_source=global_data_source,
+    )
+
+
+@pytest.fixture
+def group(db):  # noqa: ARG001
+    """Create a group."""
+    return Group.objects.create(name="Testers", created_by=uuid.uuid4())
+
+
+@pytest.fixture
+def group_access(group, data_source):
+    """Grant the group access to the restricted data source."""
+    return GroupDataSourceAccess.objects.create(
+        data_source=data_source,
+        group=group,
+        created_by=uuid.uuid4(),
+    )
+
+
+@pytest.fixture
+def membership(group, user_id):
+    """Add the test user to the group."""
+    return GroupMembership.objects.create(
+        group=group,
+        user_id=user_id,
+        created_by=uuid.uuid4(),
+    )
+
+
+@pytest.mark.django_db
+def test_cleanup_deletes_visible_assets_for_inaccessible_types(
+    user_id,
+    focus_area,
+    restricted_asset_type,
+    group_access,  # noqa: ARG001
+    membership,
+):
+    """Test that cleanup removes VisibleAsset for types the user can no longer access."""
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=restricted_asset_type)
+
+    # Remove user from group so they lose access
+    membership.delete()
+
+    deleted_count = cleanup_stale_visible_assets([user_id])
+
+    assert deleted_count == 1
+    assert not VisibleAsset.objects.filter(
+        focus_area=focus_area, asset_type=restricted_asset_type
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_preserves_visible_assets_for_accessible_types(  # noqa: PLR0913
+    user_id,
+    focus_area,
+    restricted_asset_type,
+    global_asset_type,
+    group_access,  # noqa: ARG001
+    membership,
+):
+    """Test that cleanup keeps VisibleAsset for types the user still has access to."""
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=restricted_asset_type)
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=global_asset_type)
+
+    # Remove user from group — loses restricted, keeps global
+    membership.delete()
+
+    cleanup_stale_visible_assets([user_id])
+
+    assert not VisibleAsset.objects.filter(
+        focus_area=focus_area, asset_type=restricted_asset_type
+    ).exists()
+    assert VisibleAsset.objects.filter(focus_area=focus_area, asset_type=global_asset_type).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_preserves_other_users_visible_assets(  # noqa: PLR0913
+    user_id,
+    other_user_id,
+    focus_area,
+    other_focus_area,
+    restricted_asset_type,
+    group,
+    group_access,  # noqa: ARG001
+    membership,
+):
+    """Test that cleanup only affects the specified user's records."""
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=restricted_asset_type)
+    VisibleAsset.objects.create(focus_area=other_focus_area, asset_type=restricted_asset_type)
+
+    # Add other user to the group so they have access
+    GroupMembership.objects.create(group=group, user_id=other_user_id, created_by=uuid.uuid4())
+
+    # Remove first user from group
+    membership.delete()
+
+    cleanup_stale_visible_assets([user_id])
+
+    assert not VisibleAsset.objects.filter(
+        focus_area=focus_area, asset_type=restricted_asset_type
+    ).exists()
+    assert VisibleAsset.objects.filter(
+        focus_area=other_focus_area, asset_type=restricted_asset_type
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_preserves_visible_assets_when_user_has_access_through_another_group(  # noqa: PLR0913
+    user_id,
+    focus_area,
+    restricted_asset_type,
+    group,  # noqa: ARG001
+    group_access,  # noqa: ARG001
+    membership,
+):
+    """Test that cleanup preserves VisibleAsset when user retains access via another group."""
+    other_group = Group.objects.create(name="Other Group", created_by=uuid.uuid4())
+    GroupDataSourceAccess.objects.create(
+        data_source=restricted_asset_type.data_source, group=other_group, created_by=uuid.uuid4()
+    )
+    GroupMembership.objects.create(group=other_group, user_id=user_id, created_by=uuid.uuid4())
+
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=restricted_asset_type)
+
+    # Remove user from first group — still has access through other_group
+    membership.delete()
+
+    deleted_count = cleanup_stale_visible_assets([user_id])
+
+    assert deleted_count == 0
+    assert VisibleAsset.objects.filter(
+        focus_area=focus_area, asset_type=restricted_asset_type
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_noop_when_no_stale_records(user_id, focus_area, global_asset_type):
+    """Test that cleanup is a no-op when user has no inaccessible visible assets."""
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=global_asset_type)
+
+    deleted_count = cleanup_stale_visible_assets([user_id])
+
+    assert deleted_count == 0
+    assert VisibleAsset.objects.filter(focus_area=focus_area, asset_type=global_asset_type).exists()
+
+
+@pytest.mark.django_db
+def test_cleanup_handles_user_with_no_visible_assets(user_id):
+    """Test that cleanup succeeds when user has no VisibleAsset records."""
+    deleted_count = cleanup_stale_visible_assets([user_id])
+    assert deleted_count == 0

--- a/backend/vista-python-api/src/api/tests/views/test_group_data_source_access.py
+++ b/backend/vista-python-api/src/api/tests/views/test_group_data_source_access.py
@@ -1,0 +1,277 @@
+"""Tests for the group data source access endpoints with visible asset cleanup."""
+
+from json import dumps
+from uuid import uuid4
+
+import pytest
+
+from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.group import Group, GroupDataSourceAccess, GroupMembership
+
+http_created = 201
+http_no_content = 204
+
+admin_uuid = uuid4()
+
+
+def get_user_id_from_request(request):  # noqa: ARG001
+    """Mock user ID in request."""
+    return admin_uuid
+
+
+@pytest.fixture
+def scenario(db):  # noqa: ARG001
+    """Create test scenario."""
+    return Scenario.objects.create(name="Test", is_active=True)
+
+
+@pytest.fixture
+def data_source(db):  # noqa: ARG001
+    """Create a data source."""
+    return DataSource.objects.create(name="Restricted", owner="Test", description_md="")
+
+
+@pytest.fixture
+def category(db):  # noqa: ARG001
+    """Create an asset category."""
+    return AssetCategory.objects.create(name="Infra")
+
+
+@pytest.fixture
+def sub_category(category):
+    """Create an asset sub-category."""
+    return AssetSubCategory.objects.create(name="Transport", category=category)
+
+
+@pytest.fixture
+def asset_type(sub_category, data_source):
+    """Create an asset type linked to the data source."""
+    return AssetType.objects.create(name="Rail", sub_category=sub_category, data_source=data_source)
+
+
+@pytest.fixture
+def group(db):  # noqa: ARG001
+    """Create a group."""
+    return Group.objects.create(name="Testers", created_by=uuid4())
+
+
+@pytest.fixture
+def other_group(db):  # noqa: ARG001
+    """Create another group to keep data source restricted after revoking first group."""
+    return Group.objects.create(name="Other Group", created_by=uuid4())
+
+
+@pytest.fixture
+def user_a_id():
+    """Return user A ID."""
+    return uuid4()
+
+
+@pytest.fixture
+def user_b_id():
+    """Return user B ID."""
+    return uuid4()
+
+
+@pytest.fixture
+def membership_a(group, user_a_id):
+    """Add user A to the group."""
+    return GroupMembership.objects.create(group=group, user_id=user_a_id, created_by=uuid4())
+
+
+@pytest.fixture
+def membership_b(group, user_b_id):
+    """Add user B to the group."""
+    return GroupMembership.objects.create(group=group, user_id=user_b_id, created_by=uuid4())
+
+
+@pytest.fixture
+def group_access(group, data_source):
+    """Grant the group access to the data source."""
+    return GroupDataSourceAccess.objects.create(
+        data_source=data_source, group=group, created_by=uuid4()
+    )
+
+
+@pytest.fixture
+def other_group_access(other_group, data_source):
+    """Grant the other group access to the data source so it stays restricted."""
+    return GroupDataSourceAccess.objects.create(
+        data_source=data_source, group=other_group, created_by=uuid4()
+    )
+
+
+# --- DELETE (Revoke access) Tests ---
+
+
+@pytest.mark.django_db
+def test_revoke_data_source_access_cleans_up_visible_assets(  # noqa: PLR0913
+    scenario,
+    data_source,
+    asset_type,
+    group,
+    group_access,  # noqa: ARG001
+    other_group_access,  # noqa: ARG001
+    membership_a,
+    client,
+    monkeypatch,
+):
+    """Test revoking group data source access cleans up VisibleAsset for group members."""
+    monkeypatch.setattr(
+        "api.views.group_data_source_access.get_user_id_from_request",
+        get_user_id_from_request,
+    )
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_a.user_id, name="Map-wide", is_system=True
+    )
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/datasources/{data_source.id}/access/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert not VisibleAsset.objects.filter(focus_area=focus_area, asset_type=asset_type).exists()
+
+
+@pytest.mark.django_db
+def test_revoke_data_source_access_cleans_up_for_all_group_members(  # noqa: PLR0913
+    scenario,
+    data_source,
+    asset_type,
+    group,
+    group_access,  # noqa: ARG001
+    other_group_access,  # noqa: ARG001
+    membership_a,
+    membership_b,
+    client,
+    monkeypatch,
+):
+    """Test revoking access cleans up VisibleAsset for all members of the group."""
+    monkeypatch.setattr(
+        "api.views.group_data_source_access.get_user_id_from_request",
+        get_user_id_from_request,
+    )
+    fa_a = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_a.user_id, name="FA A", is_system=True
+    )
+    fa_b = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_b.user_id, name="FA B", is_system=True
+    )
+    va_a = VisibleAsset.objects.create(focus_area=fa_a, asset_type=asset_type)
+    va_b = VisibleAsset.objects.create(focus_area=fa_b, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/datasources/{data_source.id}/access/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert not VisibleAsset.objects.filter(id=va_a.id).exists()
+    assert not VisibleAsset.objects.filter(id=va_b.id).exists()
+
+
+@pytest.mark.django_db
+def test_revoke_data_source_access_preserves_assets_when_member_in_another_group(  # noqa: PLR0913
+    scenario,
+    data_source,
+    asset_type,
+    group,
+    other_group,
+    group_access,  # noqa: ARG001
+    other_group_access,  # noqa: ARG001
+    membership_a,
+    client,
+    monkeypatch,
+):
+    """Test revoking access preserves VisibleAsset when member has access via another group."""
+    monkeypatch.setattr(
+        "api.views.group_data_source_access.get_user_id_from_request",
+        get_user_id_from_request,
+    )
+    # User A is also in other_group which retains access
+    GroupMembership.objects.create(
+        group=other_group, user_id=membership_a.user_id, created_by=uuid4()
+    )
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_a.user_id, name="Map-wide", is_system=True
+    )
+    va = VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/datasources/{data_source.id}/access/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert VisibleAsset.objects.filter(id=va.id).exists()
+
+
+@pytest.mark.django_db
+def test_revoke_last_group_access_preserves_assets_as_ds_becomes_global(  # noqa: PLR0913
+    scenario,
+    data_source,
+    asset_type,
+    group,
+    group_access,  # noqa: ARG001
+    membership_a,
+    client,
+    monkeypatch,
+):
+    """Test revoking the last group access makes DS global so no cleanup needed."""
+    monkeypatch.setattr(
+        "api.views.group_data_source_access.get_user_id_from_request",
+        get_user_id_from_request,
+    )
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_a.user_id, name="Map-wide", is_system=True
+    )
+    va = VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    # No other_group_access — this is the only group with access
+    response = client.delete(
+        f"/api/datasources/{data_source.id}/access/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    # DS becomes globally available, so visible asset should be preserved
+    assert VisibleAsset.objects.filter(id=va.id).exists()
+
+
+# --- POST (Grant access — global to restricted transition) Tests ---
+
+
+@pytest.mark.django_db
+def test_grant_data_source_access_cleans_up_for_non_members(  # noqa: PLR0913
+    scenario, data_source, asset_type, group, membership_a, client, monkeypatch
+):
+    """Test granting group access cleans up VisibleAsset for non-members."""
+    monkeypatch.setattr(
+        "api.views.group_data_source_access.get_user_id_from_request",
+        get_user_id_from_request,
+    )
+    non_member_id = uuid4()
+    fa_non_member = FocusArea.objects.create(
+        scenario=scenario, user_id=non_member_id, name="FA Non-member", is_system=True
+    )
+    fa_member = FocusArea.objects.create(
+        scenario=scenario, user_id=membership_a.user_id, name="FA Member", is_system=True
+    )
+    va_non_member = VisibleAsset.objects.create(focus_area=fa_non_member, asset_type=asset_type)
+    va_member = VisibleAsset.objects.create(focus_area=fa_member, asset_type=asset_type)
+
+    # Grant access — data source transitions from global to restricted
+    response = client.post(
+        f"/api/datasources/{data_source.id}/access/",
+        data=dumps({"group": str(group.id)}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_created
+    # Non-member's visible asset should be cleaned up
+    assert not VisibleAsset.objects.filter(id=va_non_member.id).exists()
+    # Member's visible asset should be preserved
+    assert VisibleAsset.objects.filter(id=va_member.id).exists()

--- a/backend/vista-python-api/src/api/tests/views/test_group_memberships.py
+++ b/backend/vista-python-api/src/api/tests/views/test_group_memberships.py
@@ -6,7 +6,9 @@ from uuid import uuid4
 import pytest
 
 from api.domain.cognito_user import IdpUser
-from api.models.group import Group, GroupMembership
+from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.group import Group, GroupDataSourceAccess, GroupMembership
 
 http_created = 201
 http_no_content = 204
@@ -151,3 +153,90 @@ def test_remove_group_member_returns_403_for_general_user(group, client, monkeyp
         content_type="application/json",
     )
     assert response.status_code == http_forbidden
+
+
+# --- Visible Asset Cleanup Tests ---
+
+
+@pytest.mark.django_db
+def test_remove_member_cleans_up_stale_visible_assets(group, members, client):  # noqa: ARG001
+    """Test that removing a member deletes their VisibleAsset for restricted types."""
+    user_id = idp_user_a.id
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=user_id, name="Map-wide", is_system=True
+    )
+    data_source = DataSource.objects.create(name="Restricted", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(
+        name="Rail", sub_category=sub_cat, data_source=data_source
+    )
+    GroupDataSourceAccess.objects.create(data_source=data_source, group=group, created_by=uuid4())
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/groups/{group.id}/members/{user_id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert not VisibleAsset.objects.filter(focus_area=focus_area, asset_type=asset_type).exists()
+
+
+@pytest.mark.django_db
+def test_remove_member_preserves_visible_assets_for_global_types(group, members, client):  # noqa: ARG001
+    """Test that removing a member keeps VisibleAsset for globally available types."""
+    user_id = idp_user_a.id
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=user_id, name="Map-wide", is_system=True
+    )
+    global_ds = DataSource.objects.create(name="Global", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(name="Roads", sub_category=sub_cat, data_source=global_ds)
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/groups/{group.id}/members/{user_id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert VisibleAsset.objects.filter(focus_area=focus_area, asset_type=asset_type).exists()
+
+
+@pytest.mark.django_db
+def test_remove_member_preserves_visible_assets_when_access_via_another_group(
+    group,
+    members,  # noqa: ARG001
+    client,
+):
+    """Test removing a member preserves VisibleAsset if they retain access via another group."""
+    user_id = idp_user_a.id
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=user_id, name="Map-wide", is_system=True
+    )
+    data_source = DataSource.objects.create(name="Restricted", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(
+        name="Rail", sub_category=sub_cat, data_source=data_source
+    )
+    GroupDataSourceAccess.objects.create(data_source=data_source, group=group, created_by=uuid4())
+    other_group = Group.objects.create(name="Other", created_by=uuid4())
+    GroupDataSourceAccess.objects.create(
+        data_source=data_source, group=other_group, created_by=uuid4()
+    )
+    GroupMembership.objects.create(group=other_group, user_id=user_id, created_by=uuid4())
+    VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/groups/{group.id}/members/{user_id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    assert VisibleAsset.objects.filter(focus_area=focus_area, asset_type=asset_type).exists()

--- a/backend/vista-python-api/src/api/tests/views/test_groups.py
+++ b/backend/vista-python-api/src/api/tests/views/test_groups.py
@@ -6,7 +6,9 @@ from uuid import uuid4
 import pytest
 
 from api.domain.cognito_user import IdpUser
-from api.models.group import Group, GroupMembership
+from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.group import Group, GroupDataSourceAccess, GroupMembership
 
 http_ok = 200
 http_created = 201
@@ -369,6 +371,85 @@ def test_delete_group_returns_403_for_general_user(group, client, monkeypatch):
     )
     assert response.status_code == http_forbidden
     assert Group.objects.filter(id=group.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_group_cleans_up_stale_visible_assets(group, members, client):
+    """Test that deleting a group cleans up VisibleAsset for all former members."""
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    data_source = DataSource.objects.create(name="Restricted", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(
+        name="Rail", sub_category=sub_cat, data_source=data_source
+    )
+    # Two groups have access — deleting one keeps data source restricted
+    other_group = Group.objects.create(name="Other", created_by=uuid4())
+    GroupDataSourceAccess.objects.create(data_source=data_source, group=group, created_by=uuid4())
+    GroupDataSourceAccess.objects.create(
+        data_source=data_source, group=other_group, created_by=uuid4()
+    )
+
+    visible_assets = []
+    for member in members:
+        fa = FocusArea.objects.create(
+            scenario=scenario, user_id=member.user_id, name="Map-wide", is_system=True
+        )
+        va = VisibleAsset.objects.create(focus_area=fa, asset_type=asset_type)
+        visible_assets.append(va)
+
+    response = client.delete(
+        f"/api/groups/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    for va in visible_assets:
+        assert not VisibleAsset.objects.filter(id=va.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_group_preserves_visible_assets_when_member_in_another_group(group, members, client):
+    """Test deleting a group preserves VisibleAsset when member has access via another group."""
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    data_source = DataSource.objects.create(name="Restricted", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(
+        name="Rail", sub_category=sub_cat, data_source=data_source
+    )
+    other_group = Group.objects.create(name="Other", created_by=uuid4())
+    GroupDataSourceAccess.objects.create(data_source=data_source, group=group, created_by=uuid4())
+    GroupDataSourceAccess.objects.create(
+        data_source=data_source, group=other_group, created_by=uuid4()
+    )
+
+    # Add first member to other_group so they retain access
+    member_with_access = members[0]
+    member_without_access = members[1]
+    GroupMembership.objects.create(
+        group=other_group, user_id=member_with_access.user_id, created_by=uuid4()
+    )
+
+    fa_with = FocusArea.objects.create(
+        scenario=scenario, user_id=member_with_access.user_id, name="FA With", is_system=True
+    )
+    fa_without = FocusArea.objects.create(
+        scenario=scenario, user_id=member_without_access.user_id, name="FA Without", is_system=True
+    )
+    va_with = VisibleAsset.objects.create(focus_area=fa_with, asset_type=asset_type)
+    va_without = VisibleAsset.objects.create(focus_area=fa_without, asset_type=asset_type)
+
+    response = client.delete(
+        f"/api/groups/{group.id}/",
+        content_type="application/json",
+    )
+
+    assert response.status_code == http_no_content
+    # Member with access via other_group should be preserved
+    assert VisibleAsset.objects.filter(id=va_with.id).exists()
+    # Member without access via other_group should be cleaned up
+    assert not VisibleAsset.objects.filter(id=va_without.id).exists()
 
 
 def _get_member_id_list(members):

--- a/backend/vista-python-api/src/api/tests/views/test_users.py
+++ b/backend/vista-python-api/src/api/tests/views/test_users.py
@@ -8,7 +8,9 @@ from uuid import uuid4
 import pytest
 
 from api.domain.cognito_user import IdpUser
-from api.models.group import Group, GroupMembership
+from api.models import FocusArea, Scenario, VisibleAsset
+from api.models.asset_type import AssetCategory, AssetSubCategory, AssetType, DataSource
+from api.models.group import Group, GroupDataSourceAccess, GroupMembership
 from api.models.user_invite import UserInvite
 
 new_user_uuid = uuid4()
@@ -513,6 +515,29 @@ def test_delete_user_returns_403_for_general_user(client, monkeypatch):
     monkeypatch.setattr("api.views.users.Administrator", Administrator)
     response = client.delete(f"/api/users/{new_user_uuid}/")
     assert response.status_code == http_forbidden
+
+
+@pytest.mark.django_db
+def test_delete_user_cleans_up_stale_visible_assets(client, group, members):  # noqa: ARG001
+    """Test that deleting a user cleans up their stale visible assets."""
+    scenario = Scenario.objects.create(name="Test", is_active=True)
+    focus_area = FocusArea.objects.create(
+        scenario=scenario, user_id=new_user_uuid, name="Map-wide", is_system=True
+    )
+    data_source = DataSource.objects.create(name="DS", owner="T", description_md="")
+    category = AssetCategory.objects.create(name="Infra")
+    sub_cat = AssetSubCategory.objects.create(name="Transport", category=category)
+    asset_type = AssetType.objects.create(
+        name="Rail", sub_category=sub_cat, data_source=data_source
+    )
+    GroupDataSourceAccess.objects.create(data_source=data_source, group=group, created_by=uuid4())
+    visible_asset = VisibleAsset.objects.create(focus_area=focus_area, asset_type=asset_type)
+
+    with patch("api.views.users.IdpRepository"):
+        response = client.delete(f"/api/users/{new_user_uuid}/")
+
+    assert response.status_code == http_no_content
+    assert not VisibleAsset.objects.filter(id=visible_asset.id).exists()
 
 
 # --- DELETE expired user invite tests ---

--- a/backend/vista-python-api/src/api/views/group_data_source_access.py
+++ b/backend/vista-python-api/src/api/views/group_data_source_access.py
@@ -5,9 +5,10 @@ from typing import ClassVar
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 
-from api.models import DataSource, GroupDataSourceAccess
+from api.models import AssetType, DataSource, FocusArea, GroupDataSourceAccess, GroupMembership
 from api.permissions import Administrator
 from api.serializers import GroupDataSourceAccessSerializer
+from api.services.data_source_access_service import cleanup_stale_visible_assets
 from api.utils.auth import get_user_id_from_request
 
 
@@ -32,3 +33,24 @@ class GroupDataSourceAccessViewSet(viewsets.ModelViewSet):
         """Doctor create request with authenticated user for created field."""
         data_source = get_object_or_404(DataSource, pk=self.kwargs["data_source_id"])
         serializer.save(created_by=get_user_id_from_request(self.request), data_source=data_source)
+        self._cleanup_affected_users(data_source)
+
+    def perform_destroy(self, instance):
+        """Delete the access record and clean up stale visible assets for affected users."""
+        affected_user_ids = list(
+            GroupMembership.objects.filter(group=instance.group).values_list("user_id", flat=True)
+        )
+        super().perform_destroy(instance)
+        cleanup_stale_visible_assets(affected_user_ids)
+
+    def _cleanup_affected_users(self, data_source):
+        """Clean up visible assets for users who lost access to a data source's asset types."""
+        asset_type_ids = AssetType.objects.filter(data_source=data_source).values_list(
+            "id", flat=True
+        )
+        affected_user_ids = list(
+            FocusArea.objects.filter(visible_assets__asset_type_id__in=asset_type_ids)
+            .values_list("user_id", flat=True)
+            .distinct()
+        )
+        cleanup_stale_visible_assets(affected_user_ids)

--- a/backend/vista-python-api/src/api/views/group_memberships.py
+++ b/backend/vista-python-api/src/api/views/group_memberships.py
@@ -8,6 +8,7 @@ from api.models import GroupMembership
 from api.permissions import Administrator
 from api.repository.external.idp_repository import IdpRepository
 from api.serializers import GroupMembershipSerializer
+from api.services.data_source_access_service import cleanup_stale_visible_assets
 from api.utils.auth import get_user_id_from_request
 
 
@@ -45,3 +46,9 @@ class GroupMembershipViewSet(viewsets.ModelViewSet):
         serializer.save(
             created_by=get_user_id_from_request(self.request), group_id=self.kwargs["group_id"]
         )
+
+    def perform_destroy(self, instance):
+        """Delete the membership and clean up stale visible assets."""
+        user_id = instance.user_id
+        super().perform_destroy(instance)
+        cleanup_stale_visible_assets([user_id])

--- a/backend/vista-python-api/src/api/views/groups.py
+++ b/backend/vista-python-api/src/api/views/groups.py
@@ -8,6 +8,7 @@ from api.models import Group
 from api.permissions import Administrator
 from api.repository.external.idp_repository import IdpRepository
 from api.serializers import GroupSerializer
+from api.services.data_source_access_service import cleanup_stale_visible_assets
 from api.utils.auth import get_user_id_from_request
 
 
@@ -39,3 +40,9 @@ class GroupViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         """Doctor create request with authenticated user for created field."""
         serializer.save(created_by=get_user_id_from_request(self.request))
+
+    def perform_destroy(self, instance):
+        """Delete the group and clean up stale visible assets for all former members."""
+        affected_user_ids = list(instance.members.values_list("user_id", flat=True))
+        super().perform_destroy(instance)
+        cleanup_stale_visible_assets(affected_user_ids)

--- a/backend/vista-python-api/src/api/views/users.py
+++ b/backend/vista-python-api/src/api/views/users.py
@@ -15,6 +15,7 @@ from api.models.user_invite import UserInvite
 from api.permissions import Administrator
 from api.repository.external.idp_repository import IdpRepository
 from api.serializers import IdpUserSerializer, UserCreateSerializer, UserInviteSerializer
+from api.services.data_source_access_service import cleanup_stale_visible_assets
 from api.utils.auth import get_user_id_from_request
 
 
@@ -85,6 +86,7 @@ class ApplicationUserViewSet(ModelViewSet):
         self.idp_repository.remove_user_from_vista(pk)
         UserInvite.objects.filter(user_id=pk).delete()
         GroupMembership.objects.filter(user_id=pk).delete()
+        cleanup_stale_visible_assets([pk])
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=False, methods=["post"], url_path="resolve-invites")


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

When users lose access to restricted data sources their VisibleAsset records were persisting in the database and would incorrectly reappear if the user was later re-added to a group.

Cleans up when:
- A member is removed from a group
- A group's data source access is revoked
- A group's data source access is granted (global to restricted)
- A group or user is deleted

## How Has This Been Tested?

Unit/integration tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.
