### PR TITLE
feat(dpav-2405): view dependent assets visibility icon should be blue when active

### DIFF
--- a/frontend/src/components/map-v2/panels/AssetDetailsPanel.tsx
+++ b/frontend/src/components/map-v2/panels/AssetDetailsPanel.tsx
@@ -96,7 +96,7 @@ const ConnectedAssetLink = ({ label, isVisible, onToggleVisibility, onNavigate }
             </Typography>
             <ArrowForwardIcon sx={{ fontSize: '16px' }} />
         </Link>
-        <IconButton size="small" onClick={onToggleVisibility}>
+        <IconButton size="small" color={isVisible ? 'primary' : 'default'} onClick={onToggleVisibility}>
             {isVisible ? <VisibilityIcon /> : <VisibilityOffIcon />}
         </IconButton>
     </Box>


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context
When user clicks View Dependent Assets, active Visibility IconButton needs to be blue.

## Description
When button is active, colour is set to primary (Blue)

## How Has This Been Tested?
Tested and verified locally.

## Screenshots (if appropriate):
<img width="212" height="368" alt="image" src="https://github.com/user-attachments/assets/0cc9118e-b0b9-4cb1-a2cc-0f6d38d43e91" />


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [ ] I have added tests to cover my changes.
